### PR TITLE
fix: 安装说明 API 地址与 fastify-task 迁移表名

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-document",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "用来部署一个开发者文档系统.",
   "scripts": {
     "init": "npm run init-server && husky",

--- a/server/sql/升级fastify-task-2-started-at.sql
+++ b/server/sql/升级fastify-task-2-started-at.sql
@@ -1,62 +1,74 @@
--- 为 tasks 表添加 startedAt 字段
+-- @kne/fastify-task ^2 任务表字段升级（表名：t_task_task）
 DO
 $$
 BEGIN
-    IF
-NOT EXISTS (
+    IF NOT EXISTS (
         SELECT 1
         FROM information_schema.columns
-        WHERE table_name = 't_task'
-        AND column_name = 'started_at'
+        WHERE table_name = 't_task_task'
+          AND column_name = 'started_at'
     ) THEN
-ALTER TABLE t_task
-    ADD COLUMN "started_at" TIMESTAMP WITH TIME ZONE;
+        ALTER TABLE t_task_task
+            ADD COLUMN "started_at" TIMESTAMP WITH TIME ZONE;
 
-COMMENT
-ON COLUMN t_task."started_at" IS '任务实际开始执行时间';
-END IF;
+        COMMENT ON COLUMN t_task_task."started_at" IS '任务实际开始执行时间';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 't_task_task'
+          AND column_name = 'completed_at'
+    ) THEN
+        ALTER TABLE t_task_task
+            ADD COLUMN "completed_at" TIMESTAMP WITH TIME ZONE;
+
+        COMMENT ON COLUMN t_task_task."completed_at" IS '任务完成时间';
+    END IF;
 END $$;
 
--- 兼容旧数据：将已完成任务的 created_at 作为 startedAt 的回退值
-UPDATE t_task
+-- 兼容旧数据：将已开始/已完成任务的 created_at 作为 started_at 回退值
+UPDATE t_task_task
 SET "started_at" = created_at
 WHERE "started_at" IS NULL
-  AND status IN ('running', 'success', 'failed', 'canceled');
+  AND status IN ('running', 'waiting', 'success', 'failed', 'canceled');
+
 -- 新增字段（幂等）
-ALTER TABLE t_task ADD COLUMN IF NOT EXISTS "timeout" INTEGER NOT NULL DEFAULT 3600000;
-ALTER TABLE t_task ALTER COLUMN "timeout" SET DEFAULT 3600000;
-COMMENT ON COLUMN t_task."timeout" IS '任务超时时间（毫秒），0表示不超时，默认3600000ms';
+ALTER TABLE t_task_task ADD COLUMN IF NOT EXISTS "timeout" INTEGER NOT NULL DEFAULT 3600000;
+ALTER TABLE t_task_task ALTER COLUMN "timeout" SET DEFAULT 3600000;
+COMMENT ON COLUMN t_task_task."timeout" IS '任务超时时间（毫秒），0表示不超时，默认3600000ms';
 
-ALTER TABLE t_task ADD COLUMN IF NOT EXISTS "priority" INTEGER NOT NULL DEFAULT 0;
-COMMENT ON COLUMN t_task."priority" IS '任务优先级，数值越大越优先';
+ALTER TABLE t_task_task ADD COLUMN IF NOT EXISTS "priority" INTEGER NOT NULL DEFAULT 0;
+COMMENT ON COLUMN t_task_task."priority" IS '任务优先级，数值越大越优先';
 
-ALTER TABLE t_task ADD COLUMN IF NOT EXISTS "parent_task_id" BIGINT;
-COMMENT ON COLUMN t_task."parent_task_id" IS '父任务ID，用于任务依赖/链式执行';
+ALTER TABLE t_task_task ADD COLUMN IF NOT EXISTS "parent_task_id" BIGINT;
+COMMENT ON COLUMN t_task_task."parent_task_id" IS '父任务ID，用于任务依赖/链式执行';
 
-ALTER TABLE t_task ADD COLUMN IF NOT EXISTS "retry_count" INTEGER NOT NULL DEFAULT 0;
-COMMENT ON COLUMN t_task."retry_count" IS '已重试次数';
+ALTER TABLE t_task_task ADD COLUMN IF NOT EXISTS "retry_count" INTEGER NOT NULL DEFAULT 0;
+COMMENT ON COLUMN t_task_task."retry_count" IS '已重试次数';
 
-ALTER TABLE t_task ADD COLUMN IF NOT EXISTS "max_retries" INTEGER NOT NULL DEFAULT 0;
-COMMENT ON COLUMN t_task."max_retries" IS '最大重试次数，0表示不自动重试';
+ALTER TABLE t_task_task ADD COLUMN IF NOT EXISTS "max_retries" INTEGER NOT NULL DEFAULT 0;
+COMMENT ON COLUMN t_task_task."max_retries" IS '最大重试次数，0表示不自动重试';
 
-ALTER TABLE t_task ADD COLUMN IF NOT EXISTS "completed_user_id" BIGINT;
-COMMENT ON COLUMN t_task."completed_user_id" IS '完成任务的用户ID';
+ALTER TABLE t_task_task ADD COLUMN IF NOT EXISTS "completed_user_id" BIGINT;
+COMMENT ON COLUMN t_task_task."completed_user_id" IS '完成任务的用户ID';
 
 -- 修改字段默认值
-ALTER TABLE t_task ALTER COLUMN "input" SET DEFAULT NULL;
-ALTER TABLE t_task ALTER COLUMN "output" SET DEFAULT NULL;
+ALTER TABLE t_task_task ALTER COLUMN "input" SET DEFAULT NULL;
+ALTER TABLE t_task_task ALTER COLUMN "output" SET DEFAULT NULL;
 
 -- 新增索引（幂等）
-CREATE INDEX IF NOT EXISTS idx_t_task_parent_task_id ON t_task ("parent_task_id");
-CREATE INDEX IF NOT EXISTS idx_t_task_priority ON t_task ("priority");
+CREATE INDEX IF NOT EXISTS idx_t_task_task_parent_task_id ON t_task_task ("parent_task_id");
+CREATE INDEX IF NOT EXISTS idx_t_task_task_priority ON t_task_task ("priority");
 
 -- 新增外键（幂等）
 DO $$
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'fk_t_task_parent_task'
-  ) THEN
-ALTER TABLE t_task ADD CONSTRAINT fk_t_task_parent_task
-    FOREIGN KEY ("parent_task_id") REFERENCES t_task (id);
-END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'fk_t_task_task_parent_task'
+    ) THEN
+        ALTER TABLE t_task_task
+            ADD CONSTRAINT fk_t_task_task_parent_task
+            FOREIGN KEY ("parent_task_id") REFERENCES t_task_task (id);
+    END IF;
 END $$;

--- a/src/components/AdminDevManagement/InstallGuide/index.js
+++ b/src/components/AdminDevManagement/InstallGuide/index.js
@@ -28,8 +28,9 @@ const CopySection = ({ title, content, onCopy, copyLabel }) => (
 );
 
 const resolveSyncUrl = () => {
-  const root = (window.runtimeApiUrl || '').replace(/\/$/, '');
-  return root ? `${root}/api/v1` : 'http://localhost:8061/api/v1';
+  const runtimeRoot = (window.runtimeApiUrl || '').replace(/\/$/, '');
+  const root = runtimeRoot || window.location.origin.replace(/\/$/, '');
+  return `${root}/api/v1`;
 };
 
 const buildInitCommand = ({ syncUrl, mcpUrl, tokenValue, target }) =>


### PR DESCRIPTION
## Summary
- 安装说明页初始化命令改用当前页面 `origin` 生成 sync-url / mcp-url，不再 fallback 到写死的 `localhost:8061`
- 修正 `server/sql/升级fastify-task-2-started-at.sql` 表名为 `t_task_task`，并补 `completed_at` 等 fastify-task v2 字段
- 版本：0.1.4 → 0.1.5

## Background
PR #18 合并后补充的 fix 提交未进入 master，本 PR 单独合入。

## Test plan
- [ ] 打开 `/admin/dev-management/install`，确认初始化命令中的 URL 为当前站点 origin
- [ ] 在生产/测试库执行 `psql $DATABASE_URL -f server/sql/升级fastify-task-2-started-at.sql`，确认 `t_task_task.started_at` 存在且任务 runner 不再报错

Made with [Cursor](https://cursor.com)