### PR TITLE
feat: Open API 同步自动创建与远程组件版本回写

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,22 @@
 - `x-openapi-expire`
 - `x-openapi-signature`
 
-触发同步：
+触发同步（**后台无记录时会自动创建**，再异步拉 npm / 部署）：
 
 ```bash
-# NPM 包同步
+# NPM 包同步（不存在则 create：isPublic=true；type 仅创建时生效，缺省 other）
 curl -X POST http://localhost:8061/api/v1/open-api/sync/npm-package \
   -H 'Content-Type: application/json' \
   -H 'x-openapi-appid: ...' \
   -H 'x-openapi-timestamp: ...' \
   -H 'x-openapi-expire: ...' \
   -H 'x-openapi-signature: ...' \
-  -d '{"packageName":"@kne/xxx"}'
+  -d '{"packageName":"@kne/xxx","type":"frontend"}'
 
-# 远程组件部署
+# 远程组件部署（不存在则 create；packageName 缺省时按 @kne-components/{remote}）
 curl -X POST http://localhost:8061/api/v1/open-api/sync/remote-component \
   ... \
-  -d '{"remote":"components-core"}'
+  -d '{"remote":"components-core","packageName":"@kne-components/components-core"}'
 ```
 
 ### HTTP MCP（用户登录 token）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-document",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "用来部署一个开发者文档系统.",
   "scripts": {
     "init": "npm run init-server && husky",

--- a/server/libs/controllers/open-api.js
+++ b/server/libs/controllers/open-api.js
@@ -9,13 +9,18 @@ module.exports = fp(async (fastify, options) => {
     {
       onRequest: [authenticate.openApi],
       schema: {
-        summary: 'Open API 触发 NPM 包同步',
+        summary: 'Open API 触发 NPM 包同步（不存在则自动创建后同步）',
         body: {
           type: 'object',
           properties: {
             packageName: { type: 'string' },
             version: { type: 'string' },
-            registry: { type: 'string' }
+            registry: { type: 'string' },
+            type: {
+              type: 'string',
+              enum: ['frontend', 'nodejs', 'engineering', 'miniprogram', 'prompts', 'other'],
+              description: '仅自动创建时生效；缺省或非法值为 other'
+            }
           },
           required: ['packageName']
         }
@@ -31,12 +36,13 @@ module.exports = fp(async (fastify, options) => {
     {
       onRequest: [authenticate.openApi],
       schema: {
-        summary: 'Open API 触发远程组件部署',
+        summary: 'Open API 触发远程组件部署（不存在则按 remote/packageName 自动创建后部署）',
         body: {
           type: 'object',
           properties: {
             remote: { type: 'string' },
-            packageName: { type: 'string' }
+            packageName: { type: 'string' },
+            registry: { type: 'string' }
           }
         }
       }

--- a/server/libs/services/open-api.js
+++ b/server/libs/services/open-api.js
@@ -1,40 +1,95 @@
 const fp = require('fastify-plugin');
 
+const displayNameFromPackage = packageName => {
+  if (!packageName) {
+    return '';
+  }
+  return packageName.includes('/') ? packageName.split('/').slice(1).join('/') : packageName.replace(/^@/, '');
+};
+
+const deriveRemoteFromPackageName = packageName => {
+  if (!packageName) {
+    return '';
+  }
+  return packageName.includes('/') ? packageName.split('/').slice(1).join('/') : packageName.replace(/^@/, '');
+};
+
 module.exports = fp(async (fastify, options) => {
   const { models, services } = fastify[options.name];
 
-  const triggerNpmPackageSync = async ({ packageName, version, registry }) => {
-    const where = { packageName };
-    if (registry) {
-      where.registry = registry;
+  const triggerNpmPackageSync = async ({ packageName, version, registry, type }) => {
+    if (!packageName) {
+      throw new Error('packageName 不能为空');
     }
-    const pkg = await models.npmPackage.findOne({ where });
+
+    const PACKAGE_TYPES = new Set(['frontend', 'nodejs', 'engineering', 'miniprogram', 'prompts', 'other']);
+    const resolvedType = PACKAGE_TYPES.has(type) ? type : 'other';
+
+    let pkg = await models.npmPackage.findOne({ where: { packageName } });
+    let created = false;
+
     if (!pkg) {
-      const err = new Error(`未找到 npm 包: ${packageName}`);
-      err.statusCode = 404;
-      throw err;
+      pkg = await services.npmPackage.create({
+        packageName,
+        registry: registry || 'https://registry.npmjs.org',
+        name: displayNameFromPackage(packageName),
+        type: resolvedType,
+        isPublic: true
+      });
+      created = true;
     }
+
     const task = await services.task.createNpmPackageSyncTask({ targetId: pkg.id });
-    return { success: true, taskId: task.id, targetId: pkg.id, packageName, version };
+    return {
+      success: true,
+      created,
+      taskId: task.id,
+      targetId: pkg.id,
+      packageName,
+      version,
+      type: pkg.type
+    };
   };
 
-  const triggerRemoteComponentDeploy = async ({ remote, packageName }) => {
-    const where = {};
-    if (remote) {
-      where.remote = remote;
-    } else if (packageName) {
-      where.packageName = packageName;
-    } else {
+  const triggerRemoteComponentDeploy = async ({ remote, packageName, registry }) => {
+    const resolvedRemote = remote || deriveRemoteFromPackageName(packageName);
+    const resolvedPackageName = packageName || (resolvedRemote ? `@kne-components/${resolvedRemote}` : '');
+
+    if (!resolvedRemote && !resolvedPackageName) {
       throw new Error('remote 或 packageName 至少提供一个');
     }
-    const component = await models.remoteComponent.findOne({ where });
-    if (!component) {
-      const err = new Error(`未找到远程组件: ${remote || packageName}`);
-      err.statusCode = 404;
-      throw err;
+
+    const where = {};
+    if (resolvedRemote) {
+      where.remote = resolvedRemote;
+    } else {
+      where.packageName = resolvedPackageName;
     }
+
+    let component = await models.remoteComponent.findOne({ where });
+    let created = false;
+
+    if (!component) {
+      component = await services.remoteComponent.create({
+        remote: resolvedRemote || displayNameFromPackage(resolvedPackageName),
+        packageName: resolvedPackageName,
+        registry: registry || 'https://registry.npmjs.org',
+        name: resolvedRemote || displayNameFromPackage(resolvedPackageName),
+        group: 'general',
+        isPublic: true
+      });
+      created = true;
+    }
+
     const task = await services.task.createRemoteComponentDeployTask({ targetId: component.id });
-    return { success: true, taskId: task.id, targetId: component.id, remote: component.remote };
+    return {
+      success: true,
+      created,
+      taskId: task.id,
+      targetId: component.id,
+      remote: component.remote,
+      packageName: component.packageName
+    };
   };
 
   Object.assign(services, {

--- a/server/libs/services/remote-component.js
+++ b/server/libs/services/remote-component.js
@@ -15,11 +15,12 @@ module.exports = fp(async (fastify, options) => {
   const { models } = fastify[options.name];
   const { Op } = fastify.sequelize.Sequelize;
 
-  const create = async ({ remote, url, packageName, tpl, name, description, group, versions, defaultVersion, isPublic }) => {
+  const create = async ({ remote, url, packageName, registry, tpl, name, description, group, versions, defaultVersion, isPublic }) => {
     return models.remoteComponent.create({
       remote,
       url,
       packageName,
+      registry,
       tpl,
       name,
       description,
@@ -30,7 +31,7 @@ module.exports = fp(async (fastify, options) => {
     });
   };
 
-  const update = async ({ id, remote, url, packageName, tpl, name, description, group, versions, defaultVersion, isPublic }) => {
+  const update = async ({ id, remote, url, packageName, registry, tpl, name, description, group, versions, defaultVersion, isPublic }) => {
     const component = await models.remoteComponent.findByPk(id);
     if (!component) {
       throw new Error('远程组件不存在');
@@ -39,6 +40,7 @@ module.exports = fp(async (fastify, options) => {
       remote,
       url,
       packageName,
+      registry,
       tpl,
       name,
       description,
@@ -127,14 +129,17 @@ module.exports = fp(async (fastify, options) => {
   const deployComponents = async ({ id }) => {
     const component = await models.remoteComponent.findByPk(id);
     if (!component || !component.packageName) {
-      return;
+      return component;
     }
-    let examples = component.examples;
-    const npmInfo = await loadNpmInfo(component.packageName, { registry: component.registry });
-    await fs.ensureDir(path.resolve(outputPath, component.packageName));
-    if (/^@kne-components\//.test(component.packageName)) {
-      const allVersions = Object.keys(npmInfo.versions);
 
+    const npmInfo = await loadNpmInfo(component.packageName, { registry: component.registry });
+    const latestVersion = npmInfo.version;
+    const allVersions = Object.keys(npmInfo.versions || {});
+    const examples = [];
+
+    await fs.ensureDir(path.resolve(outputPath, component.packageName));
+
+    if (/^@kne-components\//.test(component.packageName)) {
       // 按大版本分组
       const majorVersionMap = new Map();
       allVersions.forEach(version => {
@@ -154,8 +159,6 @@ module.exports = fp(async (fastify, options) => {
 
       // 最多保留最近10个大版本
       const recentMajors = sortedMajors.slice(0, 10);
-
-      // 构建要部署的版本列表
       const versionsToDeploy = [];
 
       recentMajors.forEach((major, index) => {
@@ -173,7 +176,7 @@ module.exports = fp(async (fastify, options) => {
         });
 
         if (index === 0) {
-          // 最后一个大版本，最多保留5个最近小版本
+          // 最新大版本，最多保留5个最近小版本
           versionsToDeploy.push(...versions.slice(0, 5));
         } else {
           // 其他大版本，只保留该大版本的最后一个版本
@@ -181,9 +184,10 @@ module.exports = fp(async (fastify, options) => {
         }
       });
 
-      for (let currentVersion of versionsToDeploy) {
+      for (const currentVersion of versionsToDeploy) {
         const packageName = `@kne-components/${npmInfo.name}@${currentVersion}`;
-        if (await fs.exists(path.resolve(outputPath, `@kne-components/${npmInfo.name}/${currentVersion}/package.json`))) {
+        const versionPackagePath = path.resolve(outputPath, `@kne-components/${npmInfo.name}/${currentVersion}/package.json`);
+        if (await fs.exists(versionPackagePath)) {
           examples.push(currentVersion);
           continue;
         }
@@ -193,7 +197,15 @@ module.exports = fp(async (fastify, options) => {
         } catch (e) {}
       }
     }
-    await component.update({ examples });
+
+    await component.update({
+      versions: allVersions,
+      defaultVersion: latestVersion,
+      examples: [...new Set(examples)],
+      description: component.description || npmInfo.description || (npmInfo.readme ? npmInfo.readme.slice(0, 500) : null)
+    });
+
+    return component.reload();
   };
 
   Object.assign(fastify[options.name].services, {

--- a/server/libs/tasks/remoteComponentDeploy/index.js
+++ b/server/libs/tasks/remoteComponentDeploy/index.js
@@ -24,11 +24,11 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
     try {
       log({ data: { remote: component.remote, packageName: component.packageName }, message: `正在部署 ${component.remote}` });
 
-      await services.remoteComponent.deployComponents({ id: component.id });
+      const updated = await services.remoteComponent.deployComponents({ id: component.id });
 
       try {
-        await services.documentIndex.buildFromRemoteComponent(component);
-        log({ data: { remote: component.remote }, message: '文档索引构建成功' });
+        await services.documentIndex.buildFromRemoteComponent(updated || component);
+        log({ data: { remote: component.remote, defaultVersion: updated?.defaultVersion }, message: '文档索引构建成功' });
       } catch (indexError) {
         log({ data: { error: indexError.message }, message: `文档索引构建失败: ${component.remote}` });
       }
@@ -36,6 +36,7 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
       results.push({
         remote: component.remote,
         packageName: component.packageName,
+        defaultVersion: updated?.defaultVersion,
         success: true
       });
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- `sync/npm-package` / `sync/remote-component`：后台无记录时自动 create 再触发任务
- npm 包 `type` 仅接受请求体（`frontend|nodejs|engineering|miniprogram|prompts|other`），缺省/非法为 `other`；已有记录不覆盖
- 远程组件部署后回写 `versions` / `defaultVersion` / `examples`，文档索引用 reload 后的记录
- `remoteComponent.create/update` 补上 `registry`
- 版本：`0.1.5 → 0.1.6`（server `1.0.5 → 1.0.6`）

## Test plan
- [ ] 部署后对未录入的 `@kne/xxx` 调 `sync/npm-package`（带 type）应 create + 建同步任务
- [ ] 已存在包再 sync 不改 type
- [ ] 远程组件部署后后台 `defaultVersion` / `versions` / `examples` 有更新

**发布顺序：本 PR 先合并部署，再合 actions 侧传 type 的 PR。**


Made with [Cursor](https://cursor.com)