### PR TITLE
fix: 文档同步与搜索链路加固

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,22 @@
 触发同步（**后台无记录时会自动创建**，再异步拉 npm / 部署）：
 
 ```bash
-# NPM 包同步（不存在则 create：isPublic=true；type 仅创建时生效，缺省 other）
+# NPM 包同步（不存在则 create；type 可回填；version 传入同步任务）
 curl -X POST http://localhost:8061/api/v1/open-api/sync/npm-package \
   -H 'Content-Type: application/json' \
   -H 'x-openapi-appid: ...' \
   -H 'x-openapi-timestamp: ...' \
   -H 'x-openapi-expire: ...' \
   -H 'x-openapi-signature: ...' \
-  -d '{"packageName":"@kne/xxx","type":"frontend"}'
+  -d '{"packageName":"@kne/xxx","type":"frontend","version":"1.2.3"}'
 
-# 远程组件部署（不存在则 create；packageName 缺省时按 @kne-components/{remote}）
+# 远程组件部署（不存在则 create；无 url 时索引回退 npm README）
 curl -X POST http://localhost:8061/api/v1/open-api/sync/remote-component \
   ... \
   -d '{"remote":"components-core","packageName":"@kne-components/components-core"}'
 ```
+
+搜索 `document-index`：已登记包会自动建索引；`@kne/` / `@kne-components/` 无记录时校验 npm 存在后自动创建再建索引；FTS 未命中会回退到本次 ensure 的文档。
 
 ### HTTP MCP（用户登录 token）
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-document",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "用来部署一个开发者文档系统.",
   "scripts": {
     "init": "npm run init-server && husky",

--- a/server/libs/controllers/npm-package.js
+++ b/server/libs/controllers/npm-package.js
@@ -20,7 +20,7 @@ module.exports = fp(async (fastify, options) => {
             description: { type: 'string', default: '' },
             type: { type: 'string', default: '' },
             keywords: { type: 'array', items: { type: 'string' }, default: [] },
-            isPublic: { type: 'boolean', default: false }
+            isPublic: { type: 'boolean', default: true }
           },
           required: ['packageName']
         }
@@ -55,7 +55,7 @@ module.exports = fp(async (fastify, options) => {
             description: { type: 'string', default: '' },
             type: { type: 'string', default: '' },
             keywords: { type: 'array', items: { type: 'string' }, default: [] },
-            isPublic: { type: 'boolean', default: false }
+            isPublic: { type: 'boolean', default: true }
           },
           required: ['id']
         }

--- a/server/libs/controllers/open-api.js
+++ b/server/libs/controllers/open-api.js
@@ -9,7 +9,7 @@ module.exports = fp(async (fastify, options) => {
     {
       onRequest: [authenticate.openApi],
       schema: {
-        summary: 'Open API 触发 NPM 包同步（不存在则自动创建后同步）',
+        summary: 'Open API 触发 NPM 包同步（不存在则自动创建；可回填 type/registry）',
         body: {
           type: 'object',
           properties: {
@@ -19,7 +19,7 @@ module.exports = fp(async (fastify, options) => {
             type: {
               type: 'string',
               enum: ['frontend', 'nodejs', 'engineering', 'miniprogram', 'prompts', 'other'],
-              description: '仅自动创建时生效；缺省或非法值为 other'
+              description: '创建时写入；已存在且传入非 other 时可更新（不会用 other 降级）'
             }
           },
           required: ['packageName']
@@ -36,13 +36,16 @@ module.exports = fp(async (fastify, options) => {
     {
       onRequest: [authenticate.openApi],
       schema: {
-        summary: 'Open API 触发远程组件部署（不存在则按 remote/packageName 自动创建后部署）',
+        summary: 'Open API 触发远程组件部署（不存在则自动创建；无 url 时索引回退 npm README）',
         body: {
           type: 'object',
           properties: {
             remote: { type: 'string' },
             packageName: { type: 'string' },
-            registry: { type: 'string' }
+            registry: { type: 'string' },
+            url: { type: 'string' },
+            tpl: { type: 'string' },
+            version: { type: 'string' }
           }
         }
       }

--- a/server/libs/controllers/remote-component.js
+++ b/server/libs/controllers/remote-component.js
@@ -24,7 +24,7 @@ module.exports = fp(async (fastify, options) => {
             group: { type: 'string', default: '' },
             versions: { type: 'array', items: { type: 'string' }, default: [] },
             defaultVersion: { type: 'string', default: '' },
-            isPublic: { type: 'boolean', default: false }
+            isPublic: { type: 'boolean', default: true }
           },
           required: ['remote']
         }
@@ -65,7 +65,7 @@ module.exports = fp(async (fastify, options) => {
             group: { type: 'string', default: '' },
             versions: { type: 'array', items: { type: 'string' }, default: [] },
             defaultVersion: { type: 'string', default: '' },
-            isPublic: { type: 'boolean', default: false }
+            isPublic: { type: 'boolean', default: true }
           },
           required: ['id']
         }

--- a/server/libs/mcp/index.js
+++ b/server/libs/mcp/index.js
@@ -83,15 +83,18 @@ const registerTools = (mcpServer, { services, userId }) => {
   mcpServer.registerTool(
     'search_document_index',
     {
-      description: 'PostgreSQL 全文搜索组件/npm 文档索引；若 docId 尚无索引会先拉取并建索引',
+      description: '全文搜索组件/npm 文档索引；匹配已登记包会先建索引；@kne/@kne-components 无记录时会先校验 npm 存在再自动创建并建索引',
       inputSchema: z.object({
-        query: z.string().optional().describe('搜索关键词'),
+        query: z.string().describe('搜索关键词（与 docId 至少提供一个）'),
         docId: z.string().optional().describe('限定文档 id（包名或 remote）'),
         version: z.string().optional().describe('限定版本'),
         limit: z.number().optional().describe('返回条数，默认 3')
       })
     },
     async ({ query, docId, version, limit }) => {
+      if (!query && !docId) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'query 或 docId 至少提供一个' }, null, 2) }], isError: true };
+      }
       const results = await services.documentIndex.search({ query, docId, version, limit, userId, source: 'mcp' });
       return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
     }

--- a/server/libs/services/document-index.js
+++ b/server/libs/services/document-index.js
@@ -2,8 +2,17 @@ const fp = require('fastify-plugin');
 const loadNpmInfo = require('@kne/load-npm-info');
 const { buildCatalogFromReadme } = require('@kne/npm-tools');
 const { buildSearchTextFromIndex, ftsWhere, ftsOrder } = require('../utils/fts');
+const { withRetry } = require('../utils/retry');
 
-const hasValidIndex = row => row && Array.isArray(row.indexData) && row.indexData.length > 0;
+// 已构建即可（允许空目录，避免无 # 切分时反复 ensure）
+const hasValidIndex = row => Boolean(row && row.meta && row.meta.builtAt);
+
+const displayNameFromPackage = packageName => {
+  if (!packageName) {
+    return '';
+  }
+  return packageName.includes('/') ? packageName.split('/').slice(1).join('/') : packageName.replace(/^@/, '');
+};
 
 const parseTokenDocId = query => {
   if (!query) {
@@ -14,6 +23,9 @@ const parseTokenDocId = query => {
     .match(/^([^:\s]+):([A-Za-z][\w.]*)$/);
   return match ? match[1] : null;
 };
+
+const isKneNpmPackage = name => /^@kne\/[A-Za-z0-9._-]+$/.test(name || '');
+const isKneComponentsPackage = name => /^@kne-components\/[A-Za-z0-9._-]+$/.test(name || '');
 
 const pickComponentHit = (row, query) => {
   const index = row.indexData || [];
@@ -34,13 +46,147 @@ const pickComponentHit = (row, query) => {
       const component = components[entry.name];
       return component?.api && String(component.api).toLowerCase().includes(q);
     }) ||
-    index[0];
+    null;
   return { item, component: item?.name ? components[item.name] : null };
 };
 
 module.exports = fp(async (fastify, options) => {
   const { models, services } = fastify[options.name];
+  const { Op } = fastify.sequelize.Sequelize;
   const searchTextColumn = models.documentIndex.rawAttributes.searchText.field;
+
+  const resolveCatalogDocIds = async query => {
+    const q = String(query || '').trim();
+    if (!q || q.length < 2) {
+      return [];
+    }
+
+    const [exactPackages, suffixPackages, exactRemotes, fuzzyRemotes] = await Promise.all([
+      models.npmPackage.findAll({
+        where: { [Op.or]: [{ packageName: q }, { packageName: { [Op.iLike]: `%/${q}` } }] },
+        attributes: ['packageName'],
+        limit: 5,
+        order: [['updatedAt', 'DESC']]
+      }),
+      models.npmPackage.findAll({
+        where: {
+          [Op.and]: [{ packageName: { [Op.iLike]: `%${q}%` } }, { packageName: { [Op.notILike]: `%/${q}` } }, { packageName: { [Op.ne]: q } }]
+        },
+        attributes: ['packageName'],
+        limit: 3,
+        order: [['updatedAt', 'DESC']]
+      }),
+      models.remoteComponent.findAll({
+        where: { [Op.or]: [{ remote: q }, { packageName: q }, { packageName: { [Op.iLike]: `%/${q}` } }] },
+        attributes: ['remote'],
+        limit: 5,
+        order: [['updatedAt', 'DESC']]
+      }),
+      models.remoteComponent.findAll({
+        where: {
+          [Op.and]: [{ remote: { [Op.iLike]: `%${q}%` } }, { remote: { [Op.ne]: q } }]
+        },
+        attributes: ['remote'],
+        limit: 3,
+        order: [['updatedAt', 'DESC']]
+      })
+    ]);
+
+    const ids = [];
+    const seen = new Set();
+    const push = id => {
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        ids.push(id);
+      }
+    };
+    exactPackages.forEach(pkg => push(pkg.packageName));
+    exactRemotes.forEach(remote => push(remote.remote));
+    suffixPackages.forEach(pkg => push(pkg.packageName));
+    fuzzyRemotes.forEach(remote => push(remote.remote));
+    return ids.slice(0, 5);
+  };
+
+  const resolveKnePackageCandidates = ({ query, docId }) => {
+    const candidates = [];
+    const push = value => {
+      if (value && !candidates.includes(value)) {
+        candidates.push(value);
+      }
+    };
+
+    push(docId);
+    push(parseTokenDocId(query));
+
+    const q = String(query || '').trim();
+    if (!q) {
+      return candidates;
+    }
+
+    if (isKneNpmPackage(q) || isKneComponentsPackage(q)) {
+      push(q);
+      return candidates;
+    }
+
+    // 裸名：尝试 @kne/ 与 @kne-components/ 域（仅当 npm 上真实存在时才会创建）
+    if (/^[A-Za-z0-9._-]+$/.test(q)) {
+      push(`@kne/${q}`);
+      push(`@kne-components/${q}`);
+    }
+
+    return candidates;
+  };
+
+  const npmPackageExists = async packageName => {
+    try {
+      await withRetry(() => loadNpmInfo(packageName), { retries: 2, delays: [1500, 3000] });
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+
+  const ensureKneCatalogRecord = async packageName => {
+    if (isKneNpmPackage(packageName)) {
+      let pkg = await models.npmPackage.findOne({ where: { packageName } });
+      if (pkg) {
+        return { docId: packageName, kind: 'npm', record: pkg };
+      }
+      if (!(await npmPackageExists(packageName))) {
+        return null;
+      }
+      pkg = await services.npmPackage.create({
+        packageName,
+        registry: 'https://registry.npmjs.org',
+        name: displayNameFromPackage(packageName),
+        type: 'other',
+        isPublic: true
+      });
+      return { docId: packageName, kind: 'npm', record: pkg, created: true };
+    }
+
+    if (isKneComponentsPackage(packageName)) {
+      const remote = displayNameFromPackage(packageName);
+      let component = (await models.remoteComponent.findOne({ where: { remote } })) || (await models.remoteComponent.findOne({ where: { packageName } }));
+      if (component) {
+        return { docId: component.remote, kind: 'remote', record: component };
+      }
+      if (!(await npmPackageExists(packageName))) {
+        return null;
+      }
+      component = await services.remoteComponent.create({
+        remote,
+        packageName,
+        registry: 'https://registry.npmjs.org',
+        name: remote,
+        group: 'general',
+        isPublic: true
+      });
+      return { docId: component.remote, kind: 'remote', record: component, created: true };
+    }
+
+    return null;
+  };
 
   const buildFromReadme = async ({ docId, version, readme, source, readmeUrl, packageName }) => {
     const { index, components } = buildCatalogFromReadme(readme, docId);
@@ -99,9 +245,13 @@ module.exports = fp(async (fastify, options) => {
   const buildFromNpmPackage = async ({ packageName, version, registry }) => {
     const { getNpmPackageDocument } = require('@kne/npm-tools');
     const resolvedName = version ? `${packageName}@${version}` : packageName;
-    const doc = await getNpmPackageDocument(resolvedName, {
-      loadNpmInfo: name => loadNpmInfo(name, registry ? { registry } : undefined)
-    });
+    const doc = await withRetry(
+      () =>
+        getNpmPackageDocument(resolvedName, {
+          loadNpmInfo: name => loadNpmInfo(name, registry ? { registry } : undefined)
+        }),
+      { retries: 3, delays: [2000, 5000, 10000] }
+    );
     return buildFromReadme({
       docId: packageName,
       version: version || doc.version,
@@ -113,22 +263,47 @@ module.exports = fp(async (fastify, options) => {
   };
 
   const buildFromRemoteComponent = async (component, { version: versionOverride } = {}) => {
-    const { getRemoteModuleDocument } = require('@kne/npm-tools');
-    const doc = await getRemoteModuleDocument({
-      url: component.url,
-      remote: component.remote,
-      tpl: component.tpl,
-      defaultVersion: component.defaultVersion,
-      version: versionOverride || component.defaultVersion
-    });
-    return buildFromReadme({
-      docId: component.remote,
-      version: doc.version || versionOverride || component.defaultVersion || 'latest',
-      readme: doc.readme,
-      source: 'remote',
-      readmeUrl: doc.readmeUrl,
-      packageName: component.packageName
-    });
+    const version = versionOverride || component.defaultVersion;
+    try {
+      const { getRemoteModuleDocument } = require('@kne/npm-tools');
+      const doc = await getRemoteModuleDocument({
+        url: component.url,
+        remote: component.remote,
+        tpl: component.tpl,
+        defaultVersion: component.defaultVersion,
+        version
+      });
+      return buildFromReadme({
+        docId: component.remote,
+        version: doc.version || version || 'latest',
+        readme: doc.readme,
+        source: 'remote',
+        readmeUrl: doc.readmeUrl,
+        packageName: component.packageName
+      });
+    } catch (error) {
+      if (!component.packageName) {
+        throw error;
+      }
+      // 无 url/tpl 或 CDN 失败时，回退 npm README，docId 仍用 remote
+      const { getNpmPackageDocument } = require('@kne/npm-tools');
+      const resolvedName = version ? `${component.packageName}@${version}` : component.packageName;
+      const doc = await withRetry(
+        () =>
+          getNpmPackageDocument(resolvedName, {
+            loadNpmInfo: name => loadNpmInfo(name, component.registry ? { registry: component.registry } : undefined)
+          }),
+        { retries: 3, delays: [2000, 5000, 10000] }
+      );
+      return buildFromReadme({
+        docId: component.remote,
+        version: version || doc.version,
+        readme: doc.readme,
+        source: 'remote',
+        readmeUrl: doc.readmeUrl,
+        packageName: component.packageName
+      });
+    }
   };
 
   const ensureIndex = async ({ docId, version }) => {
@@ -162,12 +337,31 @@ module.exports = fp(async (fastify, options) => {
       }
     }
 
-    const component = await models.remoteComponent.findOne({ where: { remote: docId } });
+    const component = (await models.remoteComponent.findOne({ where: { remote: docId } })) || (await models.remoteComponent.findOne({ where: { packageName: docId } }));
     if (component) {
       try {
         return await buildFromRemoteComponent(component, { version });
       } catch (e) {
         fastify.log.warn({ err: e, docId }, 'ensureIndex remote component build failed');
+      }
+    }
+
+    // @kne / @kne-components：无后台记录时先创建再建索引
+    if (isKneNpmPackage(docId) || isKneComponentsPackage(docId)) {
+      try {
+        const catalog = await ensureKneCatalogRecord(docId);
+        if (catalog?.docId) {
+          if (catalog.kind === 'npm') {
+            return await buildFromNpmPackage({
+              packageName: catalog.docId,
+              version,
+              registry: catalog.record?.registry
+            });
+          }
+          return await buildFromRemoteComponent(catalog.record, { version });
+        }
+      } catch (e) {
+        fastify.log.warn({ err: e, docId }, 'ensureIndex kne auto-create failed');
       }
     }
 
@@ -181,47 +375,114 @@ module.exports = fp(async (fastify, options) => {
   };
 
   const search = async ({ query, docId, version, limit = 3, userId, source = 'rest' }) => {
-    const resolvedDocId = docId || parseTokenDocId(query);
-    if (resolvedDocId) {
-      await ensureIndex({ docId: resolvedDocId, version });
+    const normalizedQuery = String(query || '').trim();
+    if (!normalizedQuery && !docId) {
+      return [];
     }
+
+    const tokenDocId = parseTokenDocId(normalizedQuery);
+    const resolvedDocId = docId || tokenDocId;
+    const catalogDocIds = resolvedDocId ? [] : await resolveCatalogDocIds(normalizedQuery);
+    const kneCandidates = resolveKnePackageCandidates({ query: normalizedQuery, docId: resolvedDocId });
+
+    const ensureDocIds = [];
+    const seen = new Set();
+    const pushEnsure = id => {
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        ensureDocIds.push(id);
+      }
+    };
+
+    catalogDocIds.forEach(pushEnsure);
+
+    for (const candidate of kneCandidates) {
+      try {
+        if (isKneNpmPackage(candidate) || isKneComponentsPackage(candidate)) {
+          const catalog = await ensureKneCatalogRecord(candidate);
+          if (catalog?.docId) {
+            pushEnsure(catalog.docId);
+            continue;
+          }
+        }
+        pushEnsure(candidate);
+      } catch (e) {
+        fastify.log.warn({ err: e, candidate }, 'search ensureKneCatalogRecord failed');
+        pushEnsure(candidate);
+      }
+    }
+
+    for (const id of ensureDocIds) {
+      try {
+        await ensureIndex({ docId: id, version });
+      } catch (e) {
+        fastify.log.warn({ err: e, docId: id }, 'search ensureIndex failed');
+      }
+    }
+
     const where = {};
     if (docId) {
       where.docId = docId;
-    } else if (resolvedDocId) {
-      where.docId = resolvedDocId;
+    } else if (tokenDocId) {
+      where.docId = tokenDocId;
     }
     if (version) {
       where.version = version;
     }
-    if (query) {
+    if (normalizedQuery) {
       Object.assign(where, ftsWhere(searchTextColumn));
     }
 
-    const rows = await models.documentIndex.findAll({
+    let rows = await models.documentIndex.findAll({
       where,
       limit,
-      order: query ? ftsOrder(searchTextColumn) : [['updatedAt', 'DESC']],
-      bind: query ? { query } : undefined
+      order: normalizedQuery ? ftsOrder(searchTextColumn) : [['updatedAt', 'DESC']],
+      bind: normalizedQuery ? { query: normalizedQuery } : undefined
     });
 
-    const results = rows.map(row => {
-      const { item, component } = pickComponentHit(row, query);
-      return {
-        id: row.id,
-        docId: row.docId,
-        version: row.version,
-        source: row.source,
-        token: item?.token,
-        name: item?.name,
-        summary: item?.summary,
-        api: component?.api ? String(component.api).slice(0, 2000) : undefined
-      };
-    });
+    // FTS 未命中时，回退到本次 ensure 的文档
+    if ((!rows || rows.length === 0) && ensureDocIds.length > 0) {
+      rows = await models.documentIndex.findAll({
+        where: {
+          docId: { [Op.in]: ensureDocIds },
+          ...(version ? { version } : {})
+        },
+        limit,
+        order: [['updatedAt', 'DESC']]
+      });
+    }
+
+    const results = rows
+      .map(row => {
+        const { item, component } = pickComponentHit(row, normalizedQuery);
+        if (normalizedQuery && !item) {
+          return {
+            id: row.id,
+            docId: row.docId,
+            version: row.version,
+            source: row.source,
+            token: null,
+            name: null,
+            summary: row.meta?.packageName || row.docId,
+            api: undefined
+          };
+        }
+        return {
+          id: row.id,
+          docId: row.docId,
+          version: row.version,
+          source: row.source,
+          token: item?.token,
+          name: item?.name,
+          summary: item?.summary,
+          api: component?.api ? String(component.api).slice(0, 2000) : undefined
+        };
+      })
+      .filter(Boolean);
 
     await services.searchRecord.recordSearch({
       searchType: 'document_index',
-      query: query || '',
+      query: normalizedQuery || docId || '',
       results,
       userId,
       source
@@ -236,6 +497,7 @@ module.exports = fp(async (fastify, options) => {
       buildFromNpmPackage,
       buildFromRemoteComponent,
       ensureIndex,
+      ensureKneCatalogRecord,
       search
     }
   });

--- a/server/libs/services/open-api.js
+++ b/server/libs/services/open-api.js
@@ -1,5 +1,7 @@
 const fp = require('fastify-plugin');
 
+const PACKAGE_TYPES = new Set(['frontend', 'nodejs', 'engineering', 'miniprogram', 'prompts', 'other']);
+
 const displayNameFromPackage = packageName => {
   if (!packageName) {
     return '';
@@ -14,6 +16,8 @@ const deriveRemoteFromPackageName = packageName => {
   return packageName.includes('/') ? packageName.split('/').slice(1).join('/') : packageName.replace(/^@/, '');
 };
 
+const resolvePackageType = type => (PACKAGE_TYPES.has(type) ? type : null);
+
 module.exports = fp(async (fastify, options) => {
   const { models, services } = fastify[options.name];
 
@@ -22,24 +26,53 @@ module.exports = fp(async (fastify, options) => {
       throw new Error('packageName 不能为空');
     }
 
-    const PACKAGE_TYPES = new Set(['frontend', 'nodejs', 'engineering', 'miniprogram', 'prompts', 'other']);
-    const resolvedType = PACKAGE_TYPES.has(type) ? type : 'other';
-
+    const resolvedType = resolvePackageType(type);
     let pkg = await models.npmPackage.findOne({ where: { packageName } });
     let created = false;
+    let typeUpdated = false;
 
     if (!pkg) {
-      pkg = await services.npmPackage.create({
-        packageName,
-        registry: registry || 'https://registry.npmjs.org',
-        name: displayNameFromPackage(packageName),
-        type: resolvedType,
-        isPublic: true
-      });
-      created = true;
+      try {
+        pkg = await services.npmPackage.create({
+          packageName,
+          registry: registry || 'https://registry.npmjs.org',
+          name: displayNameFromPackage(packageName),
+          type: resolvedType || 'other',
+          isPublic: true
+        });
+        created = true;
+      } catch (error) {
+        pkg = await models.npmPackage.findOne({ where: { packageName } });
+        if (!pkg) {
+          throw error;
+        }
+      }
     }
 
-    const task = await services.task.createNpmPackageSyncTask({ targetId: pkg.id });
+    if (pkg) {
+      const patch = {};
+      if (registry && registry !== pkg.registry) {
+        patch.registry = registry;
+      }
+      // CI 显式非 other 类型始终更新（不会用 other 降级已有类型）
+      if (resolvedType && resolvedType !== 'other' && pkg.type !== resolvedType) {
+        patch.type = resolvedType;
+        typeUpdated = true;
+      }
+      if (Object.keys(patch).length > 0) {
+        await pkg.update(patch);
+        await pkg.reload();
+      }
+      if (typeUpdated && pkg.type === 'frontend') {
+        try {
+          await services.npmPackage.deployExamples({ id: pkg.id });
+        } catch (e) {
+          fastify.log.warn({ err: e, packageName }, 'deployExamples after type update failed');
+        }
+      }
+    }
+
+    const task = await services.task.createNpmPackageSyncTask({ targetId: pkg.id, version });
     return {
       success: true,
       created,
@@ -51,7 +84,7 @@ module.exports = fp(async (fastify, options) => {
     };
   };
 
-  const triggerRemoteComponentDeploy = async ({ remote, packageName, registry }) => {
+  const triggerRemoteComponentDeploy = async ({ remote, packageName, registry, url, tpl, version }) => {
     const resolvedRemote = remote || deriveRemoteFromPackageName(packageName);
     const resolvedPackageName = packageName || (resolvedRemote ? `@kne-components/${resolvedRemote}` : '');
 
@@ -59,29 +92,49 @@ module.exports = fp(async (fastify, options) => {
       throw new Error('remote 或 packageName 至少提供一个');
     }
 
-    const where = {};
-    if (resolvedRemote) {
-      where.remote = resolvedRemote;
-    } else {
-      where.packageName = resolvedPackageName;
-    }
-
-    let component = await models.remoteComponent.findOne({ where });
+    let component = (resolvedRemote && (await models.remoteComponent.findOne({ where: { remote: resolvedRemote } }))) || (resolvedPackageName && (await models.remoteComponent.findOne({ where: { packageName: resolvedPackageName } })));
     let created = false;
 
     if (!component) {
-      component = await services.remoteComponent.create({
-        remote: resolvedRemote || displayNameFromPackage(resolvedPackageName),
-        packageName: resolvedPackageName,
-        registry: registry || 'https://registry.npmjs.org',
-        name: resolvedRemote || displayNameFromPackage(resolvedPackageName),
-        group: 'general',
-        isPublic: true
-      });
-      created = true;
+      try {
+        component = await services.remoteComponent.create({
+          remote: resolvedRemote || displayNameFromPackage(resolvedPackageName),
+          packageName: resolvedPackageName,
+          registry: registry || 'https://registry.npmjs.org',
+          url: url || '',
+          tpl: tpl || '',
+          name: resolvedRemote || displayNameFromPackage(resolvedPackageName),
+          group: 'general',
+          isPublic: true
+        });
+        created = true;
+      } catch (error) {
+        component = (resolvedRemote && (await models.remoteComponent.findOne({ where: { remote: resolvedRemote } }))) || (resolvedPackageName && (await models.remoteComponent.findOne({ where: { packageName: resolvedPackageName } })));
+        if (!component) {
+          throw error;
+        }
+      }
+    } else {
+      const patch = {};
+      if (registry) {
+        patch.registry = registry;
+      }
+      if (url) {
+        patch.url = url;
+      }
+      if (tpl) {
+        patch.tpl = tpl;
+      }
+      if (resolvedPackageName && !component.packageName) {
+        patch.packageName = resolvedPackageName;
+      }
+      if (Object.keys(patch).length > 0) {
+        await component.update(patch);
+        await component.reload();
+      }
     }
 
-    const task = await services.task.createRemoteComponentDeployTask({ targetId: component.id });
+    const task = await services.task.createRemoteComponentDeployTask({ targetId: component.id, version });
     return {
       success: true,
       created,

--- a/server/libs/services/task.js
+++ b/server/libs/services/task.js
@@ -21,11 +21,12 @@ module.exports = fp(async (fastify, options) => {
     return result;
   };
 
-  const createNpmPackageSyncTask = async ({ targetId = 'all' } = {}) => {
+  const createNpmPackageSyncTask = async ({ targetId = 'all', version } = {}) => {
     const task = await fastify.task.services.create({
       runnerType: 'system',
       input: {
-        name: `NPM 包同步`
+        name: `NPM 包同步`,
+        version: version || null
       },
       targetId,
       targetType: 'npmPackageSync',
@@ -39,11 +40,12 @@ module.exports = fp(async (fastify, options) => {
     return result;
   };
 
-  const createRemoteComponentDeployTask = async ({ targetId = 'all' } = {}) => {
+  const createRemoteComponentDeployTask = async ({ targetId = 'all', version } = {}) => {
     const task = await fastify.task.services.create({
       runnerType: 'system',
       input: {
-        name: `远程组件部署`
+        name: `远程组件部署`,
+        version: version || null
       },
       targetId,
       targetType: 'remoteComponentDeploy',

--- a/server/libs/tasks/npmPackageSync/index.js
+++ b/server/libs/tasks/npmPackageSync/index.js
@@ -1,12 +1,11 @@
 const loadNpmInfo = require('@kne/load-npm-info');
+const { withRetry } = require('../../utils/retry');
 
 const runner = async (fastify, options, { task, polling, updateProgress, log }) => {
   const { models, services } = fastify.project;
+  const targetVersion = task.input?.version || null;
 
-  // 获取需要同步的 npm 包
-  // 如果 task.targetId 是 'all'，则同步所有包，否则同步指定的包
   const where = task.targetId === 'all' ? {} : { id: task.targetId };
-
   const packages = await models.npmPackage.findAll({ where });
 
   if (packages.length === 0) {
@@ -24,54 +23,60 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
     updateProgress(Math.round(((i + 1) / total) * 100));
 
     try {
-      log({ data: { packageName: pkg.packageName, registry: pkg.registry }, message: `正在获取 ${pkg.packageName} 的信息` });
+      log({ data: { packageName: pkg.packageName, registry: pkg.registry, targetVersion }, message: `正在获取 ${pkg.packageName} 的信息` });
 
-      // 使用支持自定义 registry 的方法获取包信息
-      const npmInfo = await loadNpmInfo(pkg.packageName, { registry: pkg.registry });
+      const npmInfo = await withRetry(() => loadNpmInfo(pkg.packageName, { registry: pkg.registry }), {
+        retries: 3,
+        delays: [2000, 5000, 10000]
+      });
 
-      // 获取最新版本
       const latestVersion = npmInfo.version;
+      const indexVersion = targetVersion || latestVersion;
 
       await services.npmPackage.deployExamples({ id: pkg.id });
 
-      // 更新数据库
       await pkg.update({
         latestVersion,
         readme: npmInfo.readme,
         distTags: npmInfo.distTags,
         versions: npmInfo.versions,
-        description: pkg.description || (npmInfo.readme ? npmInfo.readme.slice(0, 1000) : null),
-        keywords: pkg.keywords?.length > 0 ? pkg.keywords : []
+        description: pkg.description || npmInfo.description || (npmInfo.readme ? npmInfo.readme.slice(0, 1000) : null),
+        keywords: Array.isArray(npmInfo.keywords) && npmInfo.keywords.length > 0 ? npmInfo.keywords : pkg.keywords || []
       });
 
+      let indexOk = false;
       if (npmInfo.readme) {
         try {
           await services.documentIndex.buildFromNpmPackage({
             packageName: pkg.packageName,
-            version: latestVersion,
+            version: indexVersion,
             registry: pkg.registry
           });
-          log({ data: { packageName: pkg.packageName }, message: '文档索引构建成功' });
+          indexOk = true;
+          log({ data: { packageName: pkg.packageName, indexVersion }, message: '文档索引构建成功' });
         } catch (indexError) {
           log({ data: { error: indexError.message }, message: `文档索引构建失败: ${pkg.packageName}` });
         }
+      } else {
+        log({ data: { packageName: pkg.packageName }, message: '无 README，跳过文档索引' });
       }
 
       results.push({
         packageName: pkg.packageName,
         success: true,
-        latestVersion
+        latestVersion,
+        indexVersion,
+        indexOk
       });
 
-      log({ data: { packageName: pkg.packageName, latestVersion }, message: '同步成功' });
-
-      // 避免请求过于频繁
+      log({ data: { packageName: pkg.packageName, latestVersion, indexOk }, message: '同步成功' });
       await new Promise(resolve => setTimeout(resolve, 300));
     } catch (error) {
       log({ data: { error: error.message }, message: `同步 ${pkg.packageName} 失败` });
       results.push({
         packageName: pkg.packageName,
         success: false,
+        indexOk: false,
         error: error.message
       });
     }
@@ -79,13 +84,15 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
 
   const successCount = results.filter(r => r.success).length;
   const failCount = results.filter(r => !r.success).length;
+  const indexFailCount = results.filter(r => r.success && r.indexOk === false).length;
 
   return {
     success: true,
-    message: `同步完成：成功 ${successCount} 个，失败 ${failCount} 个`,
+    message: `同步完成：成功 ${successCount} 个，失败 ${failCount} 个，索引失败 ${indexFailCount} 个`,
     total: packages.length,
     successCount,
     failCount,
+    indexFailCount,
     results
   };
 };

--- a/server/libs/tasks/remoteComponentDeploy/index.js
+++ b/server/libs/tasks/remoteComponentDeploy/index.js
@@ -1,10 +1,8 @@
 const runner = async (fastify, options, { task, polling, updateProgress, log }) => {
   const { models, services } = fastify.project;
+  const targetVersion = task.input?.version || null;
 
-  // 获取需要部署的远程组件
-  // 如果 task.targetId 是 'all'，则部署所有有 packageName 的组件，否则部署指定的组件
   const where = task.targetId === 'all' ? { packageName: { [fastify.sequelize.Sequelize.Op.ne]: null } } : { id: task.targetId };
-
   const components = await models.remoteComponent.findAll({ where });
 
   if (components.length === 0) {
@@ -22,12 +20,14 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
     updateProgress(Math.round(((i + 1) / total) * 100));
 
     try {
-      log({ data: { remote: component.remote, packageName: component.packageName }, message: `正在部署 ${component.remote}` });
+      log({ data: { remote: component.remote, packageName: component.packageName, targetVersion }, message: `正在部署 ${component.remote}` });
 
       const updated = await services.remoteComponent.deployComponents({ id: component.id });
+      let indexOk = false;
 
       try {
-        await services.documentIndex.buildFromRemoteComponent(updated || component);
+        await services.documentIndex.buildFromRemoteComponent(updated || component, { version: targetVersion });
+        indexOk = true;
         log({ data: { remote: component.remote, defaultVersion: updated?.defaultVersion }, message: '文档索引构建成功' });
       } catch (indexError) {
         log({ data: { error: indexError.message }, message: `文档索引构建失败: ${component.remote}` });
@@ -37,12 +37,11 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
         remote: component.remote,
         packageName: component.packageName,
         defaultVersion: updated?.defaultVersion,
-        success: true
+        success: true,
+        indexOk
       });
 
-      log({ data: { remote: component.remote }, message: '部署成功' });
-
-      // 避免请求过于频繁
+      log({ data: { remote: component.remote, indexOk }, message: '部署成功' });
       await new Promise(resolve => setTimeout(resolve, 300));
     } catch (error) {
       log({ data: { error: error.message }, message: `部署 ${component.remote} 失败` });
@@ -50,6 +49,7 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
         remote: component.remote,
         packageName: component.packageName,
         success: false,
+        indexOk: false,
         error: error.message
       });
     }
@@ -57,13 +57,15 @@ const runner = async (fastify, options, { task, polling, updateProgress, log }) 
 
   const successCount = results.filter(r => r.success).length;
   const failCount = results.filter(r => !r.success).length;
+  const indexFailCount = results.filter(r => r.success && r.indexOk === false).length;
 
   return {
     success: true,
-    message: `部署完成：成功 ${successCount} 个，失败 ${failCount} 个`,
+    message: `部署完成：成功 ${successCount} 个，失败 ${failCount} 个，索引失败 ${indexFailCount} 个`,
     total: components.length,
     successCount,
     failCount,
+    indexFailCount,
     results
   };
 };

--- a/server/libs/utils/retry.js
+++ b/server/libs/utils/retry.js
@@ -1,0 +1,28 @@
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {{ retries?: number, delays?: number[] }} [options]
+ * @returns {Promise<T>}
+ */
+const withRetry = async (fn, { retries = 3, delays = [2000, 5000, 10000] } = {}) => {
+  let lastError;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= retries) {
+        break;
+      }
+      await sleep(delays[attempt] ?? delays[delays.length - 1]);
+    }
+  }
+  throw lastError;
+};
+
+module.exports = {
+  sleep,
+  withRetry
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- 搜索：已登记包 ensure 索引；`@kne/` / `@kne-components/` 无记录则校验 npm 后自动创建再建索引；FTS 空结果回退 ensured docId
- 远程索引无 url 时回退 npm README；空目录不再反复 ensure
- Open API：并发 findOrCreate；type/registry 回填（other 不降级）；version 传入任务
- sync 任务：loadNpmInfo 重试、keywords、indexOk
- Admin create `isPublic` 默认 true
- 版本：`0.1.6 → 0.1.7`（server `1.0.6 → 1.0.7`）

## Test plan
- [ ] MCP 搜 `react-fetch` / `@kne/react-modal`（npm 上存在）应自动建记录+索引并返回
- [ ] 远程组件无 url 部署后仍有 document_index
- [ ] Open API 带 `type:frontend` 对已存在 other 包应回填并触发 examples

**先合并部署本 PR，再合 actions hardening。**


Made with [Cursor](https://cursor.com)