### PR TITLE
feat: 文档索引段级检索与预算化 markdown 输出

### DIFF
--- a/server/libs/controllers/document-index.js
+++ b/server/libs/controllers/document-index.js
@@ -28,4 +28,22 @@ module.exports = fp(async (fastify, options) => {
         source: 'rest'
       })
   );
+
+  fastify.get(
+    `${options.prefix}/document-index/content`,
+    {
+      onRequest: [authenticate.user],
+      schema: {
+        summary: '按 ref 读取文档索引内容',
+        query: {
+          type: 'object',
+          required: ['ref'],
+          properties: {
+            ref: { type: 'string' }
+          }
+        }
+      }
+    },
+    async request => services.docRetrieval.resolveRef(request.query.ref)
+  );
 });

--- a/server/libs/mcp/index.js
+++ b/server/libs/mcp/index.js
@@ -83,27 +83,73 @@ const registerTools = (mcpServer, { services, userId }) => {
   mcpServer.registerTool(
     'search_document_index',
     {
-      description: '全文搜索组件/npm 文档索引；匹配已登记包会先建索引；@kne/@kne-components 无记录时会先校验 npm 存在再自动创建并建索引',
+      description: [
+        '写 @kne 组件 / npm 包代码前的主检索工具，返回 markdown 正文（不是 JSON）。',
+        '一次调用就在预算内给出可直接照抄的示例与 API 表格，并合并经验与后台文档命中；',
+        '匹配已登记包会先建索引，@kne/@kne-components 无记录时会先校验 npm 存在再自动创建。',
+        '',
+        '用法：',
+        '- 先调用本工具，**一次通常就够**，不要习惯性再搜一遍或换关键词重试。',
+        '- 结果里出现 truncated 或「未包含」清单，且确实需要那部分时，才用 fetch_docs，一次传多个 ref。',
+        '- 只想看某个包里有什么，用 mode="locate"（只回 ref 与一句摘要）。',
+        '',
+        '禁止：不要为了拿示例去猜 README 路径；没有 ref 支撑的 API 一律不要臆造。'
+      ].join('\n'),
       inputSchema: z.object({
-        query: z.string().describe('搜索关键词（与 docId 至少提供一个）'),
+        query: z.string().describe('搜索关键词，可用组件名、包名、token（如 components-core:FormInfo）或中文场景词'),
         docId: z.string().optional().describe('限定文档 id（包名或 remote）'),
         version: z.string().optional().describe('限定版本'),
-        limit: z.number().optional().describe('返回条数，默认 3')
+        limit: z.number().optional().describe('最多命中段数，默认 12'),
+        maxChars: z.number().optional().describe('输出预算（字符），默认 12000'),
+        mode: z.enum(['answer', 'locate']).optional().describe('answer=带正文（默认）；locate=只回 ref 与摘要')
       })
     },
-    async ({ query, docId, version, limit }) => {
+    async ({ query, docId, version, limit, maxChars, mode }) => {
       if (!query && !docId) {
-        return { content: [{ type: 'text', text: JSON.stringify({ error: 'query 或 docId 至少提供一个' }, null, 2) }], isError: true };
+        return { content: [{ type: 'text', text: 'query 或 docId 至少提供一个' }], isError: true };
       }
-      const results = await services.documentIndex.search({ query, docId, version, limit, userId, source: 'mcp' });
-      return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+      const text = await services.docRetrieval.search({
+        query,
+        docId,
+        version,
+        limit,
+        maxChars,
+        mode,
+        userId,
+        source: 'mcp'
+      });
+      return { content: [{ type: 'text', text }] };
+    }
+  );
+
+  mcpServer.registerTool(
+    'fetch_docs',
+    {
+      description: [
+        '按 ref 深读文档内容，返回 markdown。仅在 search_document_index 标注 truncated 或列出「未包含」时使用。',
+        'ref 形如：',
+        '- doc-index:{docId}@{version}#/{组件名}                 组件目录（有哪些 API 子节与示例、各多大）',
+        '- doc-index:{docId}@{version}#/{组件名}/api/{子节}      单个 API 子节（最省 token）',
+        '- doc-index:{docId}@{version}#/{组件名}/examples/{序号} 单条示例代码',
+        '- experience:{相对路径}  /  document:{id}',
+        '一次可传多个 ref，比多次调用便宜。'
+      ].join('\n'),
+      inputSchema: z.object({
+        refs: z.array(z.string()).describe('要深读的 ref 列表，最多 10 个'),
+        offset: z.number().optional().describe('内容字符偏移，用于翻页'),
+        limit: z.number().optional().describe('本次最多返回的字符数')
+      })
+    },
+    async ({ refs, offset, limit }) => {
+      const text = await services.docRetrieval.fetchRefs({ refs, offset, limit });
+      return { content: [{ type: 'text', text }] };
     }
   );
 
   mcpServer.registerTool(
     'search_document',
     {
-      description: 'PostgreSQL 全文搜索全部后台 document（含 draft/非公开）',
+      description: '只搜后台 document（含 draft/非公开）。组件与 npm 文档请用 search_document_index，它已包含后台文档命中。',
       inputSchema: z.object({
         query: z.string().describe('搜索关键词'),
         limit: z.number().optional().describe('返回条数，默认 3')
@@ -111,7 +157,8 @@ const registerTools = (mcpServer, { services, userId }) => {
     },
     async ({ query, limit }) => {
       const results = await services.document.searchByFts({ query, limit, userId, source: 'mcp' });
-      return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+      const text = results.length ? results.map(row => `## ${row.name}\nref: document:${row.id}\n状态：${row.status}\n${row.snippet || ''}`).join('\n\n') : `无命中：${query}`;
+      return { content: [{ type: 'text', text }] };
     }
   );
 };

--- a/server/libs/services/doc-retrieval.js
+++ b/server/libs/services/doc-retrieval.js
@@ -1,0 +1,148 @@
+const fp = require('fastify-plugin');
+const { renderSearchMarkdown, renderFetchMarkdown, DEFAULT_MAX_CHARS } = require('../utils/doc-render');
+const { parseRef, formatExperienceRef, experiencePathCandidates, formatDocumentRef } = require('../utils/doc-ref');
+
+const EXPERIENCE_LIMIT = 2;
+const DOCUMENT_LIMIT = 2;
+const MAX_REFS = 10;
+const EXPERIENCE_KEY_CODE_LIMIT = 3;
+
+const joinLines = parts => parts.filter(Boolean).join('\n');
+
+module.exports = fp(async (fastify, options) => {
+  const { models, services } = fastify[options.name];
+  const { Op } = fastify.sequelize.Sequelize;
+
+  const experienceHits = async ({ query, userId, source }) => {
+    if (!query) {
+      return [];
+    }
+    const rows = await services.experience.search({ query, limit: EXPERIENCE_LIMIT, userId, source, record: false });
+    return rows.map(row => ({
+      kind: 'experience',
+      ref: formatExperienceRef(row.relativePath),
+      title: row.title,
+      content: joinLines([row.problem && `问题：${row.problem}`, row.solution && `做法：${row.solution}`, row.keywords?.length ? `关键词：${row.keywords.join('、')}` : ''])
+    }));
+  };
+
+  const documentHits = async ({ query, userId, source }) => {
+    if (!query) {
+      return [];
+    }
+    const rows = await services.document.searchByFts({ query, limit: DOCUMENT_LIMIT, userId, source, record: false });
+    return rows.map(row => ({
+      kind: 'document',
+      ref: formatDocumentRef(row.id),
+      title: row.name,
+      content: row.snippet || row.name
+    }));
+  };
+
+  /**
+   * 一次调用给出可直接决策的正文：经验在前（短且高价值），组件段居中（主体），后台文档兜底。
+   * 装不下的进「未包含」清单，由调用方按 ref 决定是否深读。
+   */
+  const search = async ({ query, docId, version, limit, maxChars = DEFAULT_MAX_CHARS, mode = 'answer', userId, source = 'mcp' }) => {
+    const normalizedQuery = String(query || '').trim();
+    if (!normalizedQuery && !docId) {
+      return renderSearchMarkdown({ query: normalizedQuery, hits: [], maxChars, mode });
+    }
+
+    const [experience, indexed, documents] = await Promise.all([
+      experienceHits({ query: normalizedQuery, userId, source }).catch(e => {
+        fastify.log.warn({ err: e }, 'doc-retrieval experience search failed');
+        return [];
+      }),
+      services.documentIndex.searchSections({ query: normalizedQuery, docId, version, limit }).catch(e => {
+        fastify.log.warn({ err: e }, 'doc-retrieval section search failed');
+        return { sections: [], total: 0 };
+      }),
+      documentHits({ query: normalizedQuery, userId, source }).catch(e => {
+        fastify.log.warn({ err: e }, 'doc-retrieval document search failed');
+        return [];
+      })
+    ]);
+
+    const hits = [...experience, ...indexed.sections, ...documents];
+    const total = experience.length + indexed.total + documents.length;
+
+    await services.searchRecord.recordSearch({
+      searchType: 'document_index',
+      query: normalizedQuery || docId || '',
+      results: hits,
+      userId,
+      source
+    });
+
+    return renderSearchMarkdown({ query: normalizedQuery || docId, hits, maxChars, mode, total });
+  };
+
+  const experienceContent = content => {
+    const data = content || {};
+    const keyCode = (data.keyCode || [])
+      .slice(0, EXPERIENCE_KEY_CODE_LIMIT)
+      .map(item => `- ${item.path || ''} ${item.why || ''}\n\`\`\`${item.language || ''}\n${item.code || ''}\n\`\`\``)
+      .join('\n');
+    return joinLines([
+      data.problem && `问题：${data.problem}`,
+      data.solution && `做法：${data.solution}`,
+      data.rootCause && `根因：${data.rootCause}`,
+      data.symptoms?.length ? `表现：${data.symptoms.join('；')}` : '',
+      data.donts?.length ? `禁止：${data.donts.join('；')}` : '',
+      data.keywords?.length ? `关键词：${data.keywords.join('、')}` : '',
+      keyCode && `关键代码：\n${keyCode}`
+    ]);
+  };
+
+  const resolveRef = async ref => {
+    const parsed = parseRef(ref);
+    if (!parsed) {
+      return { ref, error: 'ref 无法解析' };
+    }
+
+    if (parsed.type === 'doc-index') {
+      const section = await services.documentIndex.getSection(parsed);
+      return { ref, ...section };
+    }
+
+    if (parsed.type === 'experience') {
+      const row = await models.experience.findOne({
+        where: { relativePath: { [Op.in]: experiencePathCandidates(parsed.relativePath) } }
+      });
+      if (!row) {
+        return { ref, error: '经验不存在' };
+      }
+      return { ref, heading: `经验 · ${row.title}`, content: experienceContent(row.content) };
+    }
+
+    const row = await models.document.findByPk(parsed.id, { attributes: ['id', 'name', 'content', 'status'] });
+    if (!row) {
+      return { ref, error: '文档不存在' };
+    }
+    return { ref, heading: `后台文档 · ${row.name}`, content: row.content || '' };
+  };
+
+  const fetchRefs = async ({ refs = [], offset = 0, limit }) => {
+    const list = (Array.isArray(refs) ? refs : [refs]).filter(Boolean).slice(0, MAX_REFS);
+    const items = [];
+    for (const ref of list) {
+      try {
+        const resolved = await resolveRef(ref);
+        items.push({ offset, limit, ...resolved });
+      } catch (e) {
+        fastify.log.warn({ err: e, ref }, 'doc-retrieval resolveRef failed');
+        items.push({ ref, error: e.message });
+      }
+    }
+    return renderFetchMarkdown({ items });
+  };
+
+  Object.assign(services, {
+    docRetrieval: {
+      search,
+      fetchRefs,
+      resolveRef
+    }
+  });
+});

--- a/server/libs/services/document-index.js
+++ b/server/libs/services/document-index.js
@@ -1,7 +1,10 @@
 const fp = require('fastify-plugin');
 const loadNpmInfo = require('@kne/load-npm-info');
 const { buildCatalogFromReadme, getRemoteModuleDocument, getRemoteComponentReadmeFromTarball } = require('@kne/npm-tools');
-const { buildSearchTextFromIndex, ftsWhere, ftsOrder } = require('../utils/fts');
+const { buildSearchTextFromIndex, ftsWhere, ftsOrder, hasCJK, bigrams, likeWhere } = require('../utils/fts');
+const { withApiSections, apiSectionsOf, apiMarkdownOf, htmlToMarkdown, PREAMBLE_SECTION_NAME } = require('../utils/api-markdown');
+const { rankSections, orderedComponentSections, parseTokenQuery } = require('../utils/doc-sections');
+const { formatDocIndexRef } = require('../utils/doc-ref');
 const { withRetry } = require('../utils/retry');
 
 // 必须有非空组件目录，避免空壳 builtAt 永久阻塞重建
@@ -24,57 +27,18 @@ const displayNameFromPackage = packageName => {
   return packageName.includes('/') ? packageName.split('/').slice(1).join('/') : packageName.replace(/^@/, '');
 };
 
-const parseTokenQuery = query => {
-  if (!query) {
-    return null;
-  }
-  const match = String(query)
-    .trim()
-    .match(/^([^:\s]+):([A-Za-z][\w.]*)$/);
-  return match ? { docId: match[1], componentName: match[2] } : null;
-};
-
 const parseTokenDocId = query => parseTokenQuery(query)?.docId || null;
 
 const isKneNpmPackage = name => /^@kne\/[A-Za-z0-9._-]+$/.test(name || '');
 const isKneComponentsPackage = name => /^@kne-components\/[A-Za-z0-9._-]+$/.test(name || '');
 
-const pickComponentHit = (row, query) => {
-  const index = row.indexData || [];
-  const components = row.componentsData || {};
-  if (!index.length) {
-    return { item: null, component: null };
-  }
-  if (!query) {
-    const item = index[0];
-    return { item, component: item?.name ? components[item.name] : null };
-  }
-
-  const token = parseTokenQuery(query);
-  const needles = [];
-  if (token?.componentName) {
-    needles.push(token.componentName.toLowerCase());
-  }
-  needles.push(String(query).toLowerCase());
-
-  for (const q of needles) {
-    const item =
-      index.find(entry => entry.name?.toLowerCase() === q) ||
-      index.find(entry => entry.token?.toLowerCase() === q) ||
-      index.find(entry => entry.name?.toLowerCase().includes(q)) ||
-      index.find(entry => entry.token?.toLowerCase().includes(q)) ||
-      index.find(entry => entry.summary?.toLowerCase().includes(q)) ||
-      index.find(entry => {
-        const component = components[entry.name];
-        return component?.api && String(component.api).toLowerCase().includes(q);
-      });
-    if (item) {
-      return { item, component: item?.name ? components[item.name] : null };
-    }
-  }
-
-  return { item: null, component: null };
-};
+// 候选行只用轻字段筛，避免把 searchText（可达 500KB）和 componentsData（可达 1MB+）整行拉回来
+const LIGHT_ATTRIBUTES = ['id', 'docId', 'version', 'source', 'meta'];
+const FULL_ATTRIBUTES = ['id', 'docId', 'version', 'source', 'meta', 'indexData', 'componentsData'];
+const CANDIDATE_ROW_LIMIT = 5;
+const DEFAULT_SECTION_LIMIT = 12;
+// 超出 limit 后仍然列出的 ref 条数，让调用方知道还能取什么
+const OVERFLOW_SECTION_LIMIT = 15;
 
 module.exports = fp(async (fastify, options) => {
   const { models, services } = fastify[options.name];
@@ -217,7 +181,9 @@ module.exports = fp(async (fastify, options) => {
   };
 
   const buildFromReadme = async ({ docId, version, readme, source, readmeUrl, packageName }) => {
-    const { index, components } = buildCatalogFromReadme(readme, docId);
+    const { index, components: rawComponents } = buildCatalogFromReadme(readme, docId);
+    // api 原文是 HTML（表格占 token 极多），建索引时一并产出可寻址的 markdown 子节
+    const components = withApiSections(rawComponents);
     const meta = {
       id: docId,
       version,
@@ -398,16 +364,10 @@ module.exports = fp(async (fastify, options) => {
     return existing || null;
   };
 
-  const search = async ({ query, docId, version, limit = 3, userId, source = 'rest' }) => {
-    const normalizedQuery = String(query || '').trim();
-    if (!normalizedQuery && !docId) {
-      return [];
-    }
-
-    const tokenDocId = parseTokenDocId(normalizedQuery);
-    const resolvedDocId = docId || tokenDocId;
-    const catalogDocIds = resolvedDocId ? [] : await resolveCatalogDocIds(normalizedQuery);
-    const kneCandidates = await resolveKnePackageCandidates({ query: normalizedQuery, docId: resolvedDocId });
+  const resolveEnsureDocIds = async ({ query, docId, version }) => {
+    const resolvedDocId = docId || parseTokenDocId(query);
+    const catalogDocIds = resolvedDocId ? [] : await resolveCatalogDocIds(query);
+    const kneCandidates = await resolveKnePackageCandidates({ query, docId: resolvedDocId });
 
     const ensureDocIds = [];
     const seen = new Set();
@@ -444,65 +404,243 @@ module.exports = fp(async (fastify, options) => {
       }
     }
 
-    const where = {};
-    if (docId) {
-      where.docId = docId;
-    } else if (tokenDocId) {
-      where.docId = tokenDocId;
+    return ensureDocIds;
+  };
+
+  const findCandidateRows = async ({ query, docId, version, ensureDocIds }) => {
+    const baseWhere = {};
+    const scopedDocId = docId || parseTokenDocId(query);
+    if (scopedDocId) {
+      baseWhere.docId = scopedDocId;
     }
     if (version) {
-      where.version = version;
-    }
-    if (normalizedQuery) {
-      Object.assign(where, ftsWhere(searchTextColumn));
+      baseWhere.version = version;
     }
 
-    let rows = await models.documentIndex.findAll({
-      where,
-      limit,
-      order: normalizedQuery ? ftsOrder(searchTextColumn) : [['updatedAt', 'DESC']],
-      bind: normalizedQuery ? { query: normalizedQuery } : undefined
-    });
+    const light = { attributes: LIGHT_ATTRIBUTES, limit: CANDIDATE_ROW_LIMIT };
 
-    // FTS 未命中时，回退到本次 ensure 的文档
-    if ((!rows || rows.length === 0) && ensureDocIds.length > 0) {
+    if (!query) {
+      return models.documentIndex.findAll({ ...light, where: baseWhere, order: [['updatedAt', 'DESC']] });
+    }
+
+    const byLike = async terms => {
+      const clause = likeWhere(searchTextColumn, terms);
+      if (!clause) {
+        return [];
+      }
+      return models.documentIndex.findAll({
+        ...light,
+        where: { ...baseWhere, ...clause.where },
+        order: [['updatedAt', 'DESC']],
+        bind: clause.bind
+      });
+    };
+
+    let rows = [];
+    if (!hasCJK(query)) {
       rows = await models.documentIndex.findAll({
-        where: {
-          docId: { [Op.in]: ensureDocIds },
-          ...(version ? { version } : {})
-        },
-        limit,
+        ...light,
+        where: { ...baseWhere, ...ftsWhere(searchTextColumn) },
+        order: ftsOrder(searchTextColumn),
+        bind: { query }
+      });
+    }
+    if (!rows.length) {
+      rows = await byLike([query]);
+    }
+    if (!rows.length && hasCJK(query)) {
+      rows = await byLike(bigrams(query));
+    }
+    if (!rows.length && ensureDocIds?.length) {
+      rows = await models.documentIndex.findAll({
+        ...light,
+        where: { docId: { [Op.in]: ensureDocIds }, ...(version ? { version } : {}) },
         order: [['updatedAt', 'DESC']]
       });
     }
+    return rows;
+  };
 
-    const results = rows
-      .map(row => {
-        const { item, component } = pickComponentHit(row, normalizedQuery);
-        if (normalizedQuery && !item) {
-          return {
-            id: row.id,
-            docId: row.docId,
-            version: row.version,
-            source: row.source,
-            token: null,
-            name: null,
-            summary: row.meta?.packageName || row.docId,
-            api: undefined
-          };
-        }
-        return {
-          id: row.id,
-          docId: row.docId,
-          version: row.version,
-          source: row.source,
-          token: item?.token,
-          name: item?.name,
-          summary: item?.summary,
-          api: component?.api ? String(component.api).slice(0, 2000) : undefined
-        };
-      })
-      .filter(Boolean);
+  const loadFullRows = async rows => {
+    if (!rows.length) {
+      return [];
+    }
+    const ids = rows.map(row => row.id);
+    const full = await models.documentIndex.findAll({
+      where: { id: { [Op.in]: ids } },
+      attributes: FULL_ATTRIBUTES
+    });
+    const byId = new Map(full.map(row => [row.id, row]));
+    return ids.map(id => byId.get(id)).filter(Boolean);
+  };
+
+  /**
+   * 返回排好序的「段」，段是可寻址的最小可读单位（组件概述 / API 子节 / 单条示例）。
+   * 超过 limit 的部分带 overflow 标记继续返回，交给渲染层进「未包含」清单，
+   * 避免调用方以为结果里就是全部。
+   */
+  const searchSections = async ({ query, docId, version, limit = DEFAULT_SECTION_LIMIT }) => {
+    const empty = { sections: [], total: 0 };
+    const normalizedQuery = String(query || '').trim();
+    if (!normalizedQuery && !docId) {
+      return empty;
+    }
+
+    const ensureDocIds = await resolveEnsureDocIds({ query: normalizedQuery, docId, version });
+    const candidates = await findCandidateRows({ query: normalizedQuery, docId, version, ensureDocIds });
+    const rows = await loadFullRows(candidates);
+    if (!rows.length) {
+      return empty;
+    }
+
+    const token = parseTokenQuery(normalizedQuery);
+    const ordered = token?.componentName ? orderedComponentSections({ rows, componentName: token.componentName }) : null;
+    const all = ordered || rankSections({ rows, query: normalizedQuery });
+
+    const sections = all.slice(0, limit + OVERFLOW_SECTION_LIMIT).map((section, i) => (i < limit ? section : { ...section, overflow: true }));
+    return { sections, total: all.length };
+  };
+
+  const resolveRow = async ({ docId, version }) => {
+    const where = { docId };
+    if (version && version !== 'latest') {
+      where.version = version;
+    }
+    return models.documentIndex.findOne({
+      where,
+      attributes: FULL_ATTRIBUTES,
+      order: [['updatedAt', 'DESC']]
+    });
+  };
+
+  const findComponent = (row, name) => {
+    const components = row?.componentsData || {};
+    if (components[name]) {
+      return components[name];
+    }
+    const target = String(name || '').toLowerCase();
+    return Object.values(components).find(component => String(component?.name || '').toLowerCase() === target) || null;
+  };
+
+  const componentOutline = (component, { docId, version }) => {
+    const lines = [];
+    const summary = htmlToMarkdown(component.summary);
+    if (summary) {
+      lines.push(summary, '');
+    }
+    const apiSections = apiSectionsOf(component);
+    if (apiSections.length) {
+      lines.push('可取的 API 子节：');
+      const single = apiSections.length === 1;
+      apiSections.forEach(section => {
+        const ref = formatDocIndexRef({ docId, version, name: component.name, kind: 'api', sub: single ? null : section.name });
+        lines.push(`- ${section.name === PREAMBLE_SECTION_NAME ? 'api' : section.name} (${section.md.length} chars) → ${ref}`);
+      });
+      lines.push('');
+    }
+    const examples = component.examples || [];
+    if (examples.length) {
+      lines.push('可取的示例：');
+      examples.forEach(example => {
+        const ref = formatDocIndexRef({ docId, version, name: component.name, kind: 'examples', sub: example.id });
+        lines.push(`- "${example.title}" (${String(example.code || '').length} chars) → ${ref}`);
+      });
+    }
+    return lines.join('\n').trim();
+  };
+
+  /**
+   * 按 ref 深读某一段；kind 为空时给该组件的目录（可取子节与示例及其体积）
+   */
+  const getSection = async ({ docId, version, name, kind, sub }) => {
+    const row = await resolveRow({ docId, version });
+    if (!row) {
+      return { error: `未找到文档索引 ${docId}@${version || 'latest'}` };
+    }
+    const resolvedVersion = row.version;
+    if (!name) {
+      const names = (row.indexData || []).map(item => item.name);
+      return {
+        heading: `${docId}@${resolvedVersion}`,
+        content: names.length ? `组件列表：\n${names.map(item => `- ${item} → ${formatDocIndexRef({ docId, version: resolvedVersion, name: item })}`).join('\n')}` : '该文档索引为空'
+      };
+    }
+
+    const component = findComponent(row, name);
+    if (!component) {
+      return { error: `${docId}@${resolvedVersion} 中没有组件 ${name}` };
+    }
+
+    if (!kind) {
+      return {
+        heading: `${component.name} · 目录`,
+        content: componentOutline(component, { docId, version: resolvedVersion })
+      };
+    }
+
+    if (kind === 'api') {
+      if (!sub) {
+        return { heading: `${component.name} · api`, content: apiMarkdownOf(component) };
+      }
+      const sections = apiSectionsOf(component);
+      const target = sections.find(section => section.name.toLowerCase() === String(sub).toLowerCase()) || (/^\d+$/.test(sub) ? sections[Number(sub)] : null);
+      if (!target) {
+        return { error: `${component.name} 没有 api 子节 ${sub}` };
+      }
+      return { heading: `${component.name} · api / ${target.name}`, content: target.md };
+    }
+
+    if (kind === 'examples') {
+      const examples = component.examples || [];
+      if (!sub) {
+        const content = examples.map(example => `### ${example.title}\n${example.description || ''}\n\n\`\`\`jsx\n${example.code}\n\`\`\``).join('\n\n');
+        return { heading: `${component.name} · examples`, content };
+      }
+      const target = examples.find(example => String(example.id) === String(sub)) || examples.find(example => example.title === sub);
+      if (!target) {
+        return { error: `${component.name} 没有示例 ${sub}` };
+      }
+      return {
+        heading: `${component.name} · example "${target.title}"`,
+        content: [target.description || '', `\`\`\`jsx\n${target.code}\n\`\`\``].filter(Boolean).join('\n\n')
+      };
+    }
+
+    return { error: `不支持的 ref 段类型 ${kind}` };
+  };
+
+  // 保持 REST / 管理端既有的 JSON 形态，内部改用段级排序
+  const search = async ({ query, docId, version, limit = 3, userId, source = 'rest' }) => {
+    const normalizedQuery = String(query || '').trim();
+    if (!normalizedQuery && !docId) {
+      return [];
+    }
+
+    const { sections } = await searchSections({
+      query: normalizedQuery,
+      docId,
+      version,
+      limit: Math.min(limit * 6, 30)
+    });
+
+    const results = [];
+    const seen = new Set();
+    sections.forEach(section => {
+      if (results.length >= limit || seen.has(section.token)) {
+        return;
+      }
+      seen.add(section.token);
+      results.push({
+        id: section.id,
+        docId: section.docId,
+        version: section.version,
+        source: section.source,
+        token: section.token,
+        name: section.name,
+        summary: String(section.content || '').slice(0, 400),
+        ref: section.ref
+      });
+    });
 
     await services.searchRecord.recordSearch({
       searchType: 'document_index',
@@ -522,7 +660,9 @@ module.exports = fp(async (fastify, options) => {
       buildFromRemoteComponent,
       ensureIndex,
       ensureKneCatalogRecord,
-      search
+      search,
+      searchSections,
+      getSection
     }
   });
 });

--- a/server/libs/services/document.js
+++ b/server/libs/services/document.js
@@ -1,6 +1,6 @@
 const fp = require('fastify-plugin');
 const { Op, literal } = require('sequelize');
-const { ftsWhere, ftsOrder, ftsHeadline } = require('../utils/fts');
+const { ftsWhere, ftsOrder, ftsHeadline, hasCJK, bigrams, likeWhere } = require('../utils/fts');
 
 const buildDocumentSearchText = ({ name, content }) => [name || '', content || ''].join('\n').trim();
 
@@ -182,19 +182,37 @@ module.exports = fp(async (fastify, options) => {
     };
   };
 
-  const searchByFts = async ({ query, limit = 3, userId, source = 'rest' }) => {
+  const searchByFts = async ({ query, limit = 3, userId, source = 'rest', record = true }) => {
     if (!query) {
       return [];
     }
-    const rows = await models.document.findAll({
-      where: ftsWhere(searchTextColumn),
-      limit,
-      order: ftsOrder(searchTextColumn),
-      bind: { query },
-      attributes: {
-        include: [[ftsHeadline(searchTextColumn), 'snippet']]
+
+    const attributes = ['id', 'name', 'status', 'isPublic'];
+    let rows = [];
+
+    // to_tsvector('simple') 不切 CJK，中文只能走 ILIKE
+    if (!hasCJK(query)) {
+      rows = await models.document.findAll({
+        where: ftsWhere(searchTextColumn),
+        limit,
+        order: ftsOrder(searchTextColumn),
+        bind: { query },
+        attributes: [...attributes, [ftsHeadline(searchTextColumn), 'snippet']]
+      });
+    }
+
+    if (!rows.length) {
+      const clause = likeWhere(searchTextColumn, [query]) || likeWhere(searchTextColumn, bigrams(query));
+      if (clause) {
+        rows = await models.document.findAll({
+          where: clause.where,
+          limit,
+          order: [['updatedAt', 'DESC']],
+          bind: clause.bind,
+          attributes
+        });
       }
-    });
+    }
 
     const results = rows.map(row => ({
       id: row.id,
@@ -204,13 +222,15 @@ module.exports = fp(async (fastify, options) => {
       snippet: row.get('snippet')
     }));
 
-    await services.searchRecord.recordSearch({
-      searchType: 'document',
-      query,
-      results,
-      userId,
-      source
-    });
+    if (record) {
+      await services.searchRecord.recordSearch({
+        searchType: 'document',
+        query,
+        results,
+        userId,
+        source
+      });
+    }
 
     return results;
   };

--- a/server/libs/services/experience.js
+++ b/server/libs/services/experience.js
@@ -56,7 +56,7 @@ module.exports = fp(async (fastify, options) => {
     return { exists: !!row, id: row?.id, status: row?.status };
   };
 
-  const search = async ({ query, category, limit = 3, userId, source = 'rest' }) => {
+  const search = async ({ query, category, limit = 3, userId, source = 'rest', record = true }) => {
     const where = { status: 'active' };
     if (category) {
       where.category = category;
@@ -81,13 +81,15 @@ module.exports = fp(async (fastify, options) => {
       keywords: row.keywords
     }));
 
-    await services.searchRecord.recordSearch({
-      searchType: 'experience',
-      query: query || '',
-      results,
-      userId,
-      source
-    });
+    if (record) {
+      await services.searchRecord.recordSearch({
+        searchType: 'experience',
+        query: query || '',
+        results,
+        userId,
+        source
+      });
+    }
 
     return results;
   };

--- a/server/libs/utils/api-markdown.js
+++ b/server/libs/utils/api-markdown.js
@@ -1,0 +1,115 @@
+const TurndownService = require('turndown');
+const { tables } = require('turndown-plugin-gfm');
+
+const PREAMBLE_SECTION_NAME = '概述';
+
+let turndownService = null;
+
+const getTurndown = () => {
+  if (turndownService) {
+    return turndownService;
+  }
+  const service = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-'
+  });
+  service.use(tables);
+  // 产物只给模型阅读，不再被 markdown 解析器消费；关掉转义可省掉大量 \- \_ \* 噪音
+  service.escape = value => value;
+  turndownService = service;
+  return service;
+};
+
+const stripHtml = html =>
+  String(html || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const htmlToMarkdown = html => {
+  const raw = String(html || '').trim();
+  if (!raw) {
+    return '';
+  }
+  try {
+    return getTurndown().turndown(raw).trim();
+  } catch (e) {
+    return stripHtml(raw);
+  }
+};
+
+const topHeadingLevel = html => {
+  const levels = [...String(html || '').matchAll(/<h([1-6])[\s>]/gi)].map(match => Number(match[1]));
+  return levels.length ? Math.min(...levels) : 0;
+};
+
+/**
+ * 按 api HTML 中最浅一级标题切成可寻址子节。
+ * 组件之间标题层级不统一（有 h2 起、有 h4 起），固定切 h4 会把 h5 属性表拆散。
+ */
+const splitApiSections = apiHtml => {
+  const raw = String(apiHtml || '').trim();
+  if (!raw) {
+    return [];
+  }
+
+  const level = topHeadingLevel(raw);
+  if (!level) {
+    return [{ name: PREAMBLE_SECTION_NAME, md: htmlToMarkdown(raw) }].filter(section => section.md);
+  }
+
+  const headingRe = new RegExp(`^<h${level}[^>]*>([\\s\\S]*?)</h${level}>`, 'i');
+  const chunks = raw
+    .split(new RegExp(`(?=<h${level}[\\s>])`, 'i'))
+    .map(chunk => chunk.trim())
+    .filter(Boolean);
+
+  return chunks
+    .map(chunk => {
+      const matched = chunk.match(headingRe);
+      const name = matched ? stripHtml(matched[1]) : PREAMBLE_SECTION_NAME;
+      return { name: name || PREAMBLE_SECTION_NAME, md: htmlToMarkdown(chunk) };
+    })
+    .filter(section => section.md);
+};
+
+const apiSectionsOf = component => {
+  if (!component) {
+    return [];
+  }
+  if (Array.isArray(component.apiSections) && component.apiSections.length) {
+    return component.apiSections;
+  }
+  return splitApiSections(component.api);
+};
+
+const apiMarkdownOf = component =>
+  apiSectionsOf(component)
+    .map(section => section.md)
+    .filter(Boolean)
+    .join('\n\n');
+
+/**
+ * 给 buildCatalogFromReadme 的产物补 apiSections（保留原始 api HTML 供管理端使用）
+ */
+const withApiSections = (components = {}) => {
+  const next = {};
+  Object.entries(components).forEach(([name, component]) => {
+    if (!component) {
+      return;
+    }
+    next[name] = { ...component, apiSections: splitApiSections(component.api) };
+  });
+  return next;
+};
+
+module.exports = {
+  PREAMBLE_SECTION_NAME,
+  stripHtml,
+  htmlToMarkdown,
+  splitApiSections,
+  apiSectionsOf,
+  apiMarkdownOf,
+  withApiSections
+};

--- a/server/libs/utils/doc-ref.js
+++ b/server/libs/utils/doc-ref.js
@@ -1,0 +1,72 @@
+const DOC_INDEX_PREFIX = 'doc-index:';
+const EXPERIENCE_PREFIX = 'experience:';
+const DOCUMENT_PREFIX = 'document:';
+
+const formatDocIndexRef = ({ docId, version, name, kind, sub }) => {
+  const base = `${DOC_INDEX_PREFIX}${docId}@${version || 'latest'}#/${name}`;
+  if (!kind) {
+    return base;
+  }
+  return sub === undefined || sub === null || sub === '' ? `${base}/${kind}` : `${base}/${kind}/${sub}`;
+};
+
+// 库里的 relativePath 有的带 experience/ 前缀有的不带，ref 里统一去掉，解析时两种都试
+const formatExperienceRef = relativePath => `${EXPERIENCE_PREFIX}${String(relativePath || '').replace(/^experience\//, '')}`;
+
+const experiencePathCandidates = relativePath => {
+  const clean = String(relativePath || '').replace(/^experience\//, '');
+  return [clean, `experience/${clean}`];
+};
+
+const formatDocumentRef = id => `${DOCUMENT_PREFIX}${id}`;
+
+const parseDocIndexRef = body => {
+  const [head, tail] = body.split('#/');
+  if (!head) {
+    return null;
+  }
+  // docId 自身含 @（如 @kne/scroll-loader），版本取最后一个 @ 之后
+  const at = head.lastIndexOf('@');
+  const docId = at > 0 ? head.slice(0, at) : head;
+  const version = at > 0 ? head.slice(at + 1) : null;
+  if (!tail) {
+    return { type: 'doc-index', docId, version, name: null, kind: null, sub: null };
+  }
+  const [name, kind, ...rest] = tail.split('/');
+  return {
+    type: 'doc-index',
+    docId,
+    version,
+    name: name || null,
+    kind: kind || null,
+    sub: rest.length ? rest.join('/') : null
+  };
+};
+
+const parseRef = ref => {
+  const value = String(ref || '').trim();
+  if (!value) {
+    return null;
+  }
+  if (value.startsWith(DOC_INDEX_PREFIX)) {
+    return parseDocIndexRef(value.slice(DOC_INDEX_PREFIX.length));
+  }
+  if (value.startsWith(EXPERIENCE_PREFIX)) {
+    return { type: 'experience', relativePath: value.slice(EXPERIENCE_PREFIX.length) };
+  }
+  if (value.startsWith(DOCUMENT_PREFIX)) {
+    return { type: 'document', id: value.slice(DOCUMENT_PREFIX.length) };
+  }
+  return null;
+};
+
+module.exports = {
+  DOC_INDEX_PREFIX,
+  EXPERIENCE_PREFIX,
+  DOCUMENT_PREFIX,
+  formatDocIndexRef,
+  formatExperienceRef,
+  experiencePathCandidates,
+  formatDocumentRef,
+  parseRef
+};

--- a/server/libs/utils/doc-render.js
+++ b/server/libs/utils/doc-render.js
@@ -1,0 +1,170 @@
+const DEFAULT_MAX_CHARS = 12000;
+const MIN_BLOCK_CHARS = 200;
+
+// 每类单块上限：示例是写代码时最有用的，给最多；概述与后台文档只需要一眼
+const KIND_CAPS = {
+  experience: 900,
+  summary: 1200,
+  api: 3000,
+  example: 3500,
+  document: 700
+};
+
+const KIND_LABELS = {
+  experience: '经验',
+  summary: '概述',
+  api: 'api',
+  example: 'example',
+  document: '后台文档'
+};
+
+const GROUP_LABELS = {
+  experience: '经验',
+  document: '后台文档'
+};
+
+const groupOf = hit => {
+  if (hit.kind === 'experience' || hit.kind === 'document') {
+    return GROUP_LABELS[hit.kind];
+  }
+  return `${hit.docId}@${hit.version}`;
+};
+
+const headingOf = hit => {
+  if (hit.kind === 'experience') {
+    return `经验 · ${hit.title}`;
+  }
+  if (hit.kind === 'document') {
+    return `后台文档 · ${hit.title}`;
+  }
+  if (hit.kind === 'api') {
+    return hit.title ? `${hit.name} · api / ${hit.title}` : `${hit.name} · api`;
+  }
+  if (hit.kind === 'example') {
+    return `${hit.name} · example "${hit.title}"`;
+  }
+  return `${hit.name} · 概述`;
+};
+
+const formatChars = value => (value >= 1000 ? `${(value / 1000).toFixed(1)}k` : String(value));
+
+const omittedLine = hit => {
+  const label = KIND_LABELS[hit.kind] || hit.kind;
+  const title = hit.title || hit.name || '';
+  const total = (hit.content || '').length;
+  return `- ${hit.ref} — ${label}${title ? ` "${title}"` : ''} (${total} chars)`;
+};
+
+/**
+ * 预算内渲染：命中按序铺，装不下的进「未包含」清单并注明字节数，
+ * 让调用方能判断要不要按 ref 再取，而不是猜。
+ */
+const renderSearchMarkdown = ({ query, hits = [], maxChars = DEFAULT_MAX_CHARS, mode = 'answer', total = 0 }) => {
+  if (!hits.length) {
+    return `# search: ${query || ''}\n\n无命中。可换更短的关键词（组件名 / 包名），或用 \`docId\` 限定文档后重试。`;
+  }
+
+  if (mode === 'locate') {
+    const lines = hits.map(hit => `- ${hit.ref} — ${KIND_LABELS[hit.kind] || hit.kind}${hit.title ? ` "${hit.title}"` : ''} (${(hit.content || '').length} chars)`);
+    return [`# locate: ${query || ''}   (${hits.length} hits，用 fetch_docs 按 ref 取正文)`, '', ...lines].join('\n');
+  }
+
+  const lines = [];
+  const omitted = [];
+  let used = 0;
+  let currentGroup = null;
+
+  // 「未包含」清单也要占预算，否则实际输出会明显超出调用方给的上限
+  const footerReserve = Math.min(Math.round(maxChars * 0.2), 2400);
+  const contentBudget = Math.max(maxChars - footerReserve, MIN_BLOCK_CHARS);
+
+  hits.forEach(hit => {
+    const content = String(hit.content || '').trim();
+    if (!content) {
+      return;
+    }
+    const heading = headingOf(hit);
+    const overhead = heading.length + hit.ref.length + 40;
+    const remaining = contentBudget - used;
+
+    if (hit.overflow || remaining < MIN_BLOCK_CHARS + overhead) {
+      omitted.push(hit);
+      return;
+    }
+
+    const cap = Math.min(KIND_CAPS[hit.kind] || 2000, remaining - overhead);
+    const truncated = content.length > cap;
+    const body = truncated ? content.slice(0, cap) : content;
+
+    const group = groupOf(hit);
+    if (group !== currentGroup) {
+      lines.push(`## ${group}`);
+      currentGroup = group;
+    }
+
+    lines.push(`### ${heading}${truncated ? ` (truncated ${body.length}/${content.length} chars)` : ''}`);
+    lines.push(`ref: ${hit.ref}`);
+    lines.push(body);
+    lines.push('');
+    used += body.length + overhead;
+  });
+
+  const rest = Math.max(total - hits.length, 0);
+  if (omitted.length || rest) {
+    lines.push('## 未包含（需要时用 fetch_docs 按 ref 取）');
+    omitted.forEach(hit => lines.push(omittedLine(hit)));
+    if (rest) {
+      lines.push(`- 另有 ${rest} 段未列出，可缩小关键词或用 docId 限定后重搜`);
+    }
+    lines.push('');
+  }
+
+  const body = lines.join('\n').trim();
+  const shown = hits.length - omitted.length;
+  const header = `# search: ${query || ''}   (${formatChars(body.length)} chars, 预算 ${formatChars(maxChars)}, ${shown} shown, ${omitted.length + rest} omitted)`;
+  return `${header}\n\n${body}`;
+};
+
+/**
+ * 按 ref 深读：内容按字符窗口翻页，超出部分给出 nextOffset
+ */
+const renderFetchMarkdown = ({ items = [] }) => {
+  if (!items.length) {
+    return '无有效 ref。ref 形如 `doc-index:{docId}@{version}#/{Name}/api/{子节}`。';
+  }
+
+  const lines = [];
+  items.forEach(item => {
+    if (item.error) {
+      lines.push(`## ${item.ref}`);
+      lines.push(`未找到：${item.error}`);
+      lines.push('');
+      return;
+    }
+
+    const content = String(item.content || '');
+    const offset = item.offset || 0;
+    const limit = item.limit;
+    const body = typeof limit === 'number' ? content.slice(offset, offset + limit) : content.slice(offset);
+    const end = offset + body.length;
+    const more = end < content.length;
+
+    lines.push(`## ${item.heading || item.ref}`);
+    lines.push(`ref: ${item.ref}`);
+    if (offset || more) {
+      lines.push(`范围 ${offset}-${end} / ${content.length} chars${more ? `，继续取请传 offset=${end}` : ''}`);
+    }
+    lines.push('');
+    lines.push(body);
+    lines.push('');
+  });
+
+  return lines.join('\n').trim();
+};
+
+module.exports = {
+  DEFAULT_MAX_CHARS,
+  KIND_CAPS,
+  renderSearchMarkdown,
+  renderFetchMarkdown
+};

--- a/server/libs/utils/doc-sections.js
+++ b/server/libs/utils/doc-sections.js
@@ -1,0 +1,236 @@
+const { htmlToMarkdown, apiSectionsOf, PREAMBLE_SECTION_NAME } = require('./api-markdown');
+const { formatDocIndexRef } = require('./doc-ref');
+
+const KIND_BONUS = { example: 50, api: 30, summary: 10 };
+
+const parseTokenQuery = query => {
+  if (!query) {
+    return null;
+  }
+  const match = String(query)
+    .trim()
+    .match(/^([^:\s]+):([A-Za-z][\w.]*)$/);
+  return match ? { docId: match[1], componentName: match[2] } : null;
+};
+
+const buildTerms = query => {
+  const raw = String(query || '').trim();
+  if (!raw) {
+    return [];
+  }
+  const terms = new Set();
+  const token = parseTokenQuery(raw);
+  if (token?.componentName) {
+    terms.add(token.componentName.toLowerCase());
+  }
+  terms.add(raw.toLowerCase());
+  raw
+    .toLowerCase()
+    .split(/[\s,，、/]+/)
+    .forEach(part => {
+      if (part.length >= 2) {
+        terms.add(part);
+      }
+    });
+  return [...terms];
+};
+
+const includesAny = (text, terms) => {
+  if (!text || !terms.length) {
+    return false;
+  }
+  const lower = String(text).toLowerCase();
+  return terms.some(term => lower.includes(term));
+};
+
+// 文档里组件名常写成 table-page，而查询多半写 TablePage，比较前统一去掉连字符等分隔
+const normalizeName = value =>
+  String(value || '')
+    .toLowerCase()
+    .replace(/[-_.\s]/g, '');
+
+const equalsAny = (text, terms) => {
+  const normalized = normalizeName(text);
+  return Boolean(normalized) && terms.some(term => normalizeName(term) === normalized);
+};
+
+const exampleContent = example => {
+  const parts = [];
+  if (example.description) {
+    parts.push(String(example.description).trim());
+  }
+  if (example.code) {
+    parts.push(['```jsx', String(example.code).trim(), '```'].join('\n'));
+  }
+  return parts.join('\n\n');
+};
+
+/**
+ * 把一个组件摊平成可寻址、可独立取用的段
+ */
+const componentSections = ({ component, id, docId, version, source }) => {
+  const sections = [];
+  const base = { id, docId, version, source, name: component.name, token: component.token };
+
+  const summary = htmlToMarkdown(component.summary);
+  if (summary) {
+    sections.push({
+      ...base,
+      kind: 'summary',
+      title: '',
+      content: summary,
+      ref: formatDocIndexRef({ docId, version, name: component.name })
+    });
+  }
+
+  const apiSections = apiSectionsOf(component);
+  const single = apiSections.length === 1;
+  apiSections.forEach(section => {
+    sections.push({
+      ...base,
+      kind: 'api',
+      title: section.name === PREAMBLE_SECTION_NAME ? '' : section.name,
+      content: section.md,
+      ref: formatDocIndexRef({
+        docId,
+        version,
+        name: component.name,
+        kind: 'api',
+        sub: single ? null : section.name
+      })
+    });
+  });
+
+  (component.examples || []).forEach(example => {
+    const content = exampleContent(example);
+    if (!content) {
+      return;
+    }
+    sections.push({
+      ...base,
+      kind: 'example',
+      title: example.title || `示例${example.id}`,
+      description: example.description || '',
+      content,
+      ref: formatDocIndexRef({ docId, version, name: component.name, kind: 'examples', sub: example.id })
+    });
+  });
+
+  return sections;
+};
+
+const scoreComponent = (component, terms) => {
+  if (!terms.length) {
+    return 0;
+  }
+  const name = String(component.name || '').toLowerCase();
+  const token = String(component.token || '').toLowerCase();
+  let best = 0;
+  if (equalsAny(token, terms)) {
+    best = 1000;
+  }
+  if (equalsAny(name, terms)) {
+    best = Math.max(best, 900);
+  } else if (name && terms.some(term => name.includes(term) || normalizeName(name).includes(normalizeName(term)))) {
+    best = Math.max(best, 700);
+  }
+  return best;
+};
+
+const scoreSection = (section, terms) => {
+  if (!terms.length) {
+    return 0;
+  }
+  if (section.kind === 'example') {
+    return (equalsAny(section.title, terms) ? 650 : includesAny(section.title, terms) ? 600 : 0) + (includesAny(section.description, terms) ? 500 : 0) + (includesAny(section.content, terms) ? 200 : 0);
+  }
+  if (section.kind === 'api') {
+    return (equalsAny(section.title, terms) ? 600 : includesAny(section.title, terms) ? 350 : 0) + (includesAny(section.content, terms) ? 300 : 0);
+  }
+  return includesAny(section.content, terms) ? 400 : 0;
+};
+
+const rowSections = row => {
+  const components = row.componentsData || {};
+  const sections = [];
+  Object.values(components).forEach(component => {
+    if (!component?.name) {
+      return;
+    }
+    sections.push(
+      ...componentSections({
+        component,
+        id: row.id,
+        docId: row.docId,
+        version: row.version,
+        source: row.source
+      })
+    );
+  });
+  return sections;
+};
+
+/**
+ * 跨行按段打分排序。命中的判定是「组件命中」或「段自身命中」，
+ * 组件分负责把同一组件的段聚到一起，段分负责决定先给示例还是先给 API。
+ */
+const rankSections = ({ rows, query }) => {
+  const terms = buildTerms(query);
+  const scored = [];
+
+  rows.forEach(row => {
+    const components = row.componentsData || {};
+    Object.values(components).forEach(component => {
+      if (!component?.name) {
+        return;
+      }
+      const componentScore = scoreComponent(component, terms);
+      componentSections({
+        component,
+        id: row.id,
+        docId: row.docId,
+        version: row.version,
+        source: row.source
+      }).forEach(section => {
+        const sectionScore = scoreSection(section, terms);
+        if (terms.length && !componentScore && !sectionScore) {
+          return;
+        }
+        scored.push({ ...section, score: componentScore + sectionScore + (KIND_BONUS[section.kind] || 0) });
+      });
+    });
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored;
+};
+
+/**
+ * token 精确命中时不做打分，按 概述 → API 子节 → 示例 的自然顺序给目录式结果
+ */
+const orderedComponentSections = ({ rows, componentName }) => {
+  const target = String(componentName || '').toLowerCase();
+  for (const row of rows) {
+    const components = row.componentsData || {};
+    const matched = Object.values(components).find(component => String(component?.name || '').toLowerCase() === target);
+    if (matched) {
+      return componentSections({
+        component: matched,
+        id: row.id,
+        docId: row.docId,
+        version: row.version,
+        source: row.source
+      }).map((section, i) => ({ ...section, score: 10000 - i }));
+    }
+  }
+  return null;
+};
+
+module.exports = {
+  parseTokenQuery,
+  buildTerms,
+  componentSections,
+  rowSections,
+  rankSections,
+  orderedComponentSections
+};

--- a/server/libs/utils/fts.js
+++ b/server/libs/utils/fts.js
@@ -1,6 +1,14 @@
 const { literal, Op } = require('sequelize');
+const { stripHtml, apiMarkdownOf } = require('./api-markdown');
 
 const QUERY_BIND = '$query';
+
+// 单行 searchText 会整体进 to_tsvector，超过约 1MB 会被 PG 拒绝；实测最大包（components-core）
+// 在下列配额下约 26 万字符，留足余量
+const SEARCH_TEXT_LIMIT = 500000;
+const API_CHARS_PER_COMPONENT = 8000;
+// 示例代码总量可达 79 万字符，只取开头（import 与首屏用法）足以支撑召回
+const CODE_CHARS_PER_EXAMPLE = 500;
 
 const buildSearchTextFromIndex = ({ index = [], components = {} }) => {
   const parts = [];
@@ -11,12 +19,21 @@ const buildSearchTextFromIndex = ({ index = [], components = {} }) => {
     if (!item) {
       return;
     }
-    parts.push(item.name, item.token, item.summary);
-    if (item.api) {
-      parts.push(String(item.api).slice(0, 2000));
+    parts.push(item.name, item.token, stripHtml(item.summary));
+
+    const api = apiMarkdownOf(item);
+    if (api) {
+      parts.push(api.slice(0, API_CHARS_PER_COMPONENT));
     }
+
+    (item.examples || []).forEach(example => {
+      parts.push(example.title, example.description);
+      if (example.code) {
+        parts.push(String(example.code).slice(0, CODE_CHARS_PER_EXAMPLE));
+      }
+    });
   });
-  return parts.filter(Boolean).join('\n').slice(0, 500000);
+  return parts.filter(Boolean).join('\n').slice(0, SEARCH_TEXT_LIMIT);
 };
 
 const ftsMatchSql = (column, queryParam = QUERY_BIND) => `to_tsvector('simple', coalesce(${column}, '')) @@ plainto_tsquery('simple', ${queryParam})`;
@@ -31,11 +48,57 @@ const ftsOrder = column => [literal(`${ftsRankSql(column)} DESC`)];
 
 const ftsHeadline = column => literal(`ts_headline('simple', coalesce(${column}, ''), plainto_tsquery('simple', ${QUERY_BIND}), 'MaxFragments=2,MaxWords=30,MinWords=10')`);
 
+const CJK_RE = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/;
+
+const hasCJK = value => CJK_RE.test(String(value || ''));
+
+const MAX_BIGRAMS = 8;
+
+// to_tsvector('simple') 不切 CJK，"下拉加载" 与 "下拉加载更多" 是两个不同 token，
+// 中文短语必然 0 命中，因此中文走 ILIKE：先整串，再退化成 bigram AND
+const bigrams = value => {
+  const clean = String(value || '').replace(/\s+/g, '');
+  if (clean.length <= 2) {
+    return clean ? [clean] : [];
+  }
+  const grams = [];
+  for (let i = 0; i + 2 <= clean.length; i += 1) {
+    grams.push(clean.slice(i, i + 2));
+  }
+  return [...new Set(grams)].slice(0, MAX_BIGRAMS);
+};
+
+const escapeLike = value => String(value).replace(/[\\%_]/g, char => `\\${char}`);
+
+/**
+ * 生成 ILIKE AND 条件，返回 where 片段与需要合并的 bind
+ */
+const likeWhere = (column, terms) => {
+  const usable = (terms || []).filter(Boolean);
+  if (!usable.length) {
+    return null;
+  }
+  const bind = {};
+  const clauses = usable.map((term, i) => {
+    const key = `like${i}`;
+    bind[key] = `%${escapeLike(term)}%`;
+    return `coalesce(${column}, '') ILIKE $${key}`;
+  });
+  return {
+    where: { [Op.and]: [literal(clauses.join(' AND '))] },
+    bind
+  };
+};
+
 module.exports = {
   buildSearchTextFromIndex,
   ftsMatchSql,
   ftsRankSql,
   ftsWhere,
   ftsOrder,
-  ftsHeadline
+  ftsHeadline,
+  hasCJK,
+  bigrams,
+  likeWhere,
+  SEARCH_TEXT_LIMIT
 };

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,8 @@
     "start": "node ./index.js",
     "build:md": "npx @kne/md-doc",
     "start:md": "npx @kne/md-doc --watch",
-    "sync:kne-document": "node ./scripts/sync-local-kne-document.js"
+    "sync:kne-document": "node ./scripts/sync-local-kne-document.js",
+    "rebuild:document-index": "node ./scripts/rebuild-document-index-search-text.js"
   },
   "files": [
     "index.js",
@@ -55,6 +56,8 @@
     "lodash": "^4.17.21",
     "pg": "^8.20.0",
     "qs": "^6.12.1",
+    "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/server/scripts/rebuild-document-index-search-text.js
+++ b/server/scripts/rebuild-document-index-search-text.js
@@ -1,0 +1,101 @@
+/**
+ * 给已有 document_index 补 apiSections 并重算 searchText（纯本地转换，不重新拉 README）。
+ *
+ * 背景：
+ * - api 原文是 HTML，表格占 token 极多；新检索按 h 标题切成 markdown 子节后可按 ref 精确取用
+ * - 旧 searchText 不含 examples，api 只进前 2000 字，导致示例名与中文场景词搜不到
+ *
+ * 用法（server 目录，需能连库；环境变量同服务端 DB_* / PG*）：
+ *   node ./scripts/rebuild-document-index-search-text.js
+ */
+const { Sequelize, QueryTypes } = require('sequelize');
+const { withApiSections } = require('../libs/utils/api-markdown');
+const { buildSearchTextFromIndex } = require('../libs/utils/fts');
+
+// information_schema 的标识符列是 sql_identifier 类型，node-pg 解析后为空串，统一走 pg_catalog 并 ::text
+const listColumns = async (sequelize, table) => {
+  const rows = await sequelize.query(
+    `SELECT a.attname::text AS name
+     FROM pg_attribute a
+     JOIN pg_class c ON c.oid = a.attrelid
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public' AND c.relname = :table AND a.attnum > 0 AND NOT a.attisdropped`,
+    { type: QueryTypes.SELECT, replacements: { table } }
+  );
+  return rows.map(row => row.name);
+};
+
+const pick = (columns, candidates, label) => {
+  const found = candidates.find(candidate => columns.includes(candidate));
+  if (!found) {
+    throw new Error(`未找到 ${label} 列，候选：${candidates.join(' / ')}`);
+  }
+  return found;
+};
+
+const start = async () => {
+  const env = process.env;
+  const sequelize = new Sequelize(env.DB_DATABASE || env.PGDATABASE || 'developer_document', env.DB_USERNAME || env.PGUSER || 'postgres', env.DB_PASSWORD || env.PGPASSWORD || '', {
+    host: env.DB_HOST || env.PGHOST || '127.0.0.1',
+    port: Number(env.DB_PORT || env.PGPORT || 5432),
+    dialect: 'postgres',
+    logging: false
+  });
+
+  const tables = await sequelize.query(
+    `SELECT tablename::text AS name FROM pg_tables
+     WHERE schemaname = 'public' AND tablename IN ('document_index', 't_document_index')`,
+    { type: QueryTypes.SELECT }
+  );
+  if (!tables.length) {
+    console.log('document_index table not found, skip');
+    await sequelize.close();
+    return;
+  }
+  const table = tables[0].name;
+  const columns = await listColumns(sequelize, table);
+
+  const docIdCol = pick(columns, ['doc_id', 'docId'], 'docId');
+  const indexCol = pick(columns, ['index_data', 'indexData'], 'indexData');
+  const componentsCol = pick(columns, ['components_data', 'componentsData'], 'componentsData');
+  const searchTextCol = pick(columns, ['search_text', 'searchText'], 'searchText');
+  const deletedAtCol = pick(columns, ['deleted_at', 'deletedAt'], 'deletedAt');
+  const updatedAtCol = pick(columns, ['updated_at', 'updatedAt'], 'updatedAt');
+
+  const rows = await sequelize.query(
+    `SELECT id, "${docIdCol}" AS doc_id, version, "${indexCol}" AS index_data, "${componentsCol}" AS components_data
+     FROM ${table}
+     WHERE "${deletedAtCol}" IS NULL`,
+    { type: QueryTypes.SELECT }
+  );
+
+  console.log(`table=${table} scanned=${rows.length}`);
+  let updated = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const index = Array.isArray(row.index_data) ? row.index_data : [];
+    const components = row.components_data && typeof row.components_data === 'object' ? row.components_data : {};
+    if (!Object.keys(components).length) {
+      skipped += 1;
+      continue;
+    }
+
+    const nextComponents = withApiSections(components);
+    const searchText = buildSearchTextFromIndex({ index, components: nextComponents });
+
+    await sequelize.query(`UPDATE ${table} SET "${componentsCol}" = :components, "${searchTextCol}" = :searchText, "${updatedAtCol}" = NOW() WHERE id = :id`, {
+      replacements: { components: JSON.stringify(nextComponents), searchText, id: row.id }
+    });
+    updated += 1;
+    console.log(`rebuilt ${row.doc_id}@${row.version} components=${Object.keys(nextComponents).length} searchText=${searchText.length}`);
+  }
+
+  console.log(`done. updated=${updated} skipped=${skipped}`);
+  await sequelize.close();
+};
+
+start().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- 索引语料补全 examples 与 API markdown，API 按标题切子节并落 `apiSections`
- 两段取数 + 段级打分 + CJK bigram 回退，统一经 `doc-retrieval` 网关输出
- MCP `search_document_index` 改 markdown 预算渲染，新增 `fetch_docs` 与 REST `/document-index/content`
- 新增 `rebuild:document-index` 脚本迁移已有索引

## Test plan
- [x] `search_document_index("ScrollLoader")` 一次返回经验 + API 表格 + 示例
- [x] `search_document_index("下拉加载")` CJK 查询有命中
- [x] `search_document_index("components-core:FormInfo")` 命中远程组件库 @0.6.1
- [x] `fetch_docs` 按 ref 深读 API 子节与示例分页
- [x] `npm run rebuild:document-index` 迁移已有行

## Version
server: 1.0.9 → 1.0.10

Made with [Cursor](https://cursor.com)