### PR TITLE
feat: MCP search_worklog 支持时间与创建人筛选

### DIFF
--- a/server/libs/mcp/index.js
+++ b/server/libs/mcp/index.js
@@ -81,6 +81,57 @@ const registerTools = (mcpServer, { services, userId }) => {
   );
 
   mcpServer.registerTool(
+    'search_worklog',
+    {
+      description: [
+        '查询工作日志，用于写周报/复盘。返回 markdown（按项目分组）。',
+        '',
+        '时间筛选（任选其一，默认近 7 天）：',
+        '- week="this"|"last"：按 Asia/Shanghai 自然周（周一～周日）',
+        '- days=N：近 N 天',
+        '- startAt / endAt：ISO 日期或日期时间',
+        '',
+        '创建人筛选（任选其一）：',
+        '- mine=true：当前登录用户',
+        '- creator：昵称 / 邮箱 / 用户 id（模糊匹配多人时会返回候选）',
+        '- createdUserId：精确用户 id',
+        '',
+        '还可按 project、query（标题/路径/项目名关键词）收窄。'
+      ].join('\n'),
+      inputSchema: z.object({
+        query: z.string().optional().describe('关键词（标题 / 路径 / 项目名）'),
+        project: z.string().optional().describe('项目名（模糊匹配 content.project.name）'),
+        creator: z.string().optional().describe('创建人：昵称、邮箱或用户 id'),
+        createdUserId: z.string().optional().describe('创建人用户 id（精确）'),
+        mine: z.boolean().optional().describe('仅当前 MCP 登录用户的日志'),
+        startAt: z.string().optional().describe('开始时间，ISO 日期或日期时间'),
+        endAt: z.string().optional().describe('结束时间，ISO 日期或日期时间'),
+        week: z.enum(['this', 'last']).optional().describe('this=本周，last=上周（上海时区，周一为一周起点）'),
+        days: z.number().optional().describe('近 N 天；未指定时间范围时默认 7'),
+        limit: z.number().optional().describe('最多返回条数，默认 50，上限 200'),
+        mode: z.enum(['report', 'list']).optional().describe('report=周报素材（默认）；list=紧凑列表')
+      })
+    },
+    async ({ query, project, creator, createdUserId, mine, startAt, endAt, week, days, limit, mode }) => {
+      const result = await services.worklog.search({
+        query,
+        projectName: project,
+        creator,
+        createdUserId,
+        mine,
+        startAt,
+        endAt,
+        week,
+        days,
+        limit,
+        mode,
+        currentUserId: userId
+      });
+      return { content: [{ type: 'text', text: result.text }], isError: !!result.error };
+    }
+  );
+
+  mcpServer.registerTool(
     'search_document_index',
     {
       description: [

--- a/server/libs/services/worklog.js
+++ b/server/libs/services/worklog.js
@@ -2,11 +2,212 @@ const fp = require('fastify-plugin');
 const { Op, fn, col, where: sequelizeWhere } = require('sequelize');
 const { createZipBuffer, parseZipBuffer } = require('../utils/kne-document-zip');
 const { buildPathTree } = require('../utils/kne-document-path-tree');
+const { resolveWrittenAtRange, shanghaiYmd } = require('../utils/worklog-range');
+
+const formatDay = value => {
+  if (!value) {
+    return '';
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : shanghaiYmd(date);
+};
+
+const creatorLabel = user => {
+  if (!user) {
+    return '';
+  }
+  return user.nickname || user.email || user.phone || String(user.id || '');
+};
 
 module.exports = fp(async (fastify, options) => {
   const { models, services } = fastify[options.name];
+  const userModel = fastify.account.models.user;
 
   const projectNameExpr = () => fn('jsonb_extract_path_text', col('content'), 'project', 'name');
+
+  /**
+   * 解析创建人：优先 createdUserId；其次 creator（id / 昵称 / 邮箱）；mine=true 用当前 MCP 用户
+   * 昵称/邮箱模糊匹配到多人时返回 candidates，由调用方提示
+   */
+  const resolveCreator = async ({ createdUserId, creator, mine, currentUserId }) => {
+    if (mine) {
+      if (!currentUserId) {
+        return { error: '无法解析当前用户' };
+      }
+      const me = await userModel.findByPk(currentUserId, { attributes: ['id', 'nickname', 'email', 'phone'] });
+      return { createdUserId: currentUserId, user: me };
+    }
+
+    if (createdUserId) {
+      const user = await userModel.findByPk(createdUserId, { attributes: ['id', 'nickname', 'email', 'phone'] });
+      if (!user) {
+        return { error: `找不到创建人 id=${createdUserId}` };
+      }
+      return { createdUserId, user };
+    }
+
+    const q = String(creator || '').trim();
+    if (!q) {
+      return { createdUserId: undefined, user: null };
+    }
+
+    if (/^\d{15,}$/.test(q)) {
+      const user = await userModel.findByPk(q, { attributes: ['id', 'nickname', 'email', 'phone'] });
+      if (!user) {
+        return { error: `找不到创建人 id=${q}` };
+      }
+      return { createdUserId: user.id, user };
+    }
+
+    const rows = await userModel.findAll({
+      where: {
+        [Op.or]: [{ nickname: { [Op.iLike]: `%${q}%` } }, { email: { [Op.iLike]: `%${q}%` } }]
+      },
+      attributes: ['id', 'nickname', 'email', 'phone'],
+      limit: 8
+    });
+
+    if (!rows.length) {
+      return { error: `找不到创建人：${q}` };
+    }
+    if (rows.length > 1) {
+      const exact = rows.find(row => row.nickname === q || row.email === q);
+      if (!exact) {
+        return {
+          error: `创建人「${q}」匹配到多人，请改用 createdUserId 或更精确的昵称/邮箱`,
+          candidates: rows.map(row => ({ id: row.id, nickname: row.nickname, email: row.email }))
+        };
+      }
+      return { createdUserId: exact.id, user: exact };
+    }
+    return { createdUserId: rows[0].id, user: rows[0] };
+  };
+
+  const summarizeRow = row => {
+    const content = row.content || {};
+    return {
+      id: row.id,
+      relativePath: row.relativePath,
+      title: row.title || content.title || '',
+      writtenAt: row.writtenAt,
+      project: content.project?.name || null,
+      prUrl: content.pr?.url || null,
+      prNumber: content.pr?.number || null,
+      versionBump: content.finalSolution?.versionBump || null,
+      summary: content.requirement?.summary || content.finalSolution?.summary || content.description || '',
+      creator: creatorLabel(row.createdUser),
+      createdUserId: row.createdUserId
+    };
+  };
+
+  const renderReportMarkdown = ({ items, rangeLabel, filters }) => {
+    const lines = [];
+    lines.push(`# 工作日志周报素材`);
+    lines.push('');
+    lines.push(`时间：${rangeLabel}`);
+    const filterBits = [];
+    if (filters.creatorLabel) {
+      filterBits.push(`创建人 ${filters.creatorLabel}`);
+    }
+    if (filters.projectName) {
+      filterBits.push(`项目 ${filters.projectName}`);
+    }
+    if (filters.keyword) {
+      filterBits.push(`关键词 ${filters.keyword}`);
+    }
+    if (filterBits.length) {
+      lines.push(`筛选：${filterBits.join(' · ')}`);
+    }
+    lines.push(`共 ${items.length} 条`);
+    lines.push('');
+
+    if (!items.length) {
+      lines.push('（无命中，可放宽时间或去掉创建人/项目筛选）');
+      return lines.join('\n');
+    }
+
+    const byProject = new Map();
+    items.forEach(item => {
+      const key = item.project || '（未标注项目）';
+      if (!byProject.has(key)) {
+        byProject.set(key, []);
+      }
+      byProject.get(key).push(item);
+    });
+
+    [...byProject.entries()].forEach(([project, rows]) => {
+      lines.push(`## ${project}`);
+      rows.forEach(item => {
+        const meta = [formatDay(item.writtenAt), item.creator].filter(Boolean).join(' · ');
+        lines.push(`- **${item.title || '(无标题)'}**${meta ? `（${meta}）` : ''}`);
+        if (item.summary) {
+          lines.push(`  ${item.summary}`);
+        }
+        const extras = [];
+        if (item.prUrl) {
+          extras.push(`PR: ${item.prUrl}`);
+        } else if (item.prNumber) {
+          extras.push(`PR #${item.prNumber}`);
+        }
+        if (item.versionBump) {
+          extras.push(`版本: ${item.versionBump}`);
+        }
+        if (extras.length) {
+          lines.push(`  ${extras.join(' · ')}`);
+        }
+        lines.push(`  path: ${item.relativePath}`);
+      });
+      lines.push('');
+    });
+
+    return lines.join('\n').trim() + '\n';
+  };
+
+  /**
+   * MCP / 周报查询：按时间 + 创建人 + 项目筛选，默认输出 markdown 周报素材
+   */
+  const search = async ({ query, projectName, createdUserId, creator, mine, startAt, endAt, week, days, limit = 50, mode = 'report', currentUserId } = {}) => {
+    const range = resolveWrittenAtRange({ startAt, endAt, week, days });
+    const resolved = await resolveCreator({ createdUserId, creator, mine, currentUserId });
+    if (resolved.error) {
+      const extra = resolved.candidates?.length ? `\n候选：\n${resolved.candidates.map(c => `- ${c.id} ${c.nickname || ''} ${c.email || ''}`).join('\n')}` : '';
+      return { error: resolved.error + extra, text: `错误：${resolved.error}${extra}` };
+    }
+
+    const perPage = Math.min(Math.max(Number(limit) || 50, 1), 200);
+    const { totalCount, pageData } = await list({
+      keyword: query,
+      projectName,
+      createdUserId: resolved.createdUserId,
+      writtenAtStart: range.writtenAtStart,
+      writtenAtEnd: range.writtenAtEnd,
+      perPage,
+      currentPage: 1
+    });
+
+    const items = pageData.map(summarizeRow);
+    const filters = {
+      keyword: query || '',
+      projectName: projectName || '',
+      creatorLabel: resolved.user ? creatorLabel(resolved.user) : ''
+    };
+
+    if (mode === 'list') {
+      const text = items.length
+        ? items
+            .map(item => {
+              const bits = [formatDay(item.writtenAt), item.project, item.creator].filter(Boolean).join(' · ');
+              return `- ${item.title}${bits ? `（${bits}）` : ''}\n  ${item.summary || ''}\n  ${item.relativePath}`.trim();
+            })
+            .join('\n')
+        : `无命中（${range.label}）`;
+      return { totalCount, items, range, text: `# 工作日志列表\n时间：${range.label}\n共 ${totalCount} 条（返回 ${items.length}）\n\n${text}\n` };
+    }
+
+    const text = renderReportMarkdown({ items, rangeLabel: range.label, filters });
+    const truncatedNote = totalCount > items.length ? `\n> 另有 ${totalCount - items.length} 条未列出，可增大 limit 或收窄筛选。\n` : '';
+    return { totalCount, items, range, text: text + truncatedNote };
+  };
 
   const upsert = async ({ relativePath, content, userId, skipIfExists = false }) => {
     const existing = await models.worklog.findOne({ where: { relativePath }, paranoid: false });
@@ -113,11 +314,33 @@ module.exports = fp(async (fastify, options) => {
       },
       raw: true
     });
+
+    const creatorRows = await models.worklog.findAll({
+      attributes: ['createdUserId'],
+      group: ['createdUserId'],
+      raw: true
+    });
+    const creatorIds = creatorRows.map(row => row.createdUserId).filter(Boolean);
+    const creators = creatorIds.length
+      ? (
+          await userModel.findAll({
+            where: { id: { [Op.in]: creatorIds } },
+            attributes: ['id', 'nickname', 'email', 'phone']
+          })
+        ).map(user => ({
+          id: user.id,
+          nickname: user.nickname,
+          email: user.email,
+          label: creatorLabel(user)
+        }))
+      : [];
+
     return {
       projectNames: rows
         .map(row => row.projectName)
         .filter(Boolean)
-        .sort((a, b) => a.localeCompare(b))
+        .sort((a, b) => a.localeCompare(b)),
+      creators: creators.sort((a, b) => String(a.label).localeCompare(String(b.label)))
     };
   };
 
@@ -208,6 +431,7 @@ module.exports = fp(async (fastify, options) => {
     worklog: {
       upsert,
       list,
+      search,
       detail,
       exists,
       pathTree,

--- a/server/libs/utils/worklog-range.js
+++ b/server/libs/utils/worklog-range.js
@@ -1,0 +1,72 @@
+/**
+ * 解析工作日志查询的时间范围（默认按 Asia/Shanghai 日历理解「本周/上周」）
+ * 优先级：startAt/endAt > week > days > 默认近 7 天
+ */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const parseDateInput = value => {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const shanghaiYmd = date =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(date);
+
+/** 上海时区下的「当天 0 点」对应的 Date（上海无夏令时，固定 UTC+8） */
+const startOfShanghaiDay = date => new Date(`${shanghaiYmd(date)}T00:00:00+08:00`);
+
+const shanghaiWeekdayMon0 = date => {
+  // 0=周一 … 6=周日
+  const weekday = new Intl.DateTimeFormat('en-US', { timeZone: 'Asia/Shanghai', weekday: 'short' }).format(date);
+  return { Mon: 0, Tue: 1, Wed: 2, Thu: 3, Fri: 4, Sat: 5, Sun: 6 }[weekday] ?? 0;
+};
+
+const resolveWrittenAtRange = ({ startAt, endAt, week, days } = {}) => {
+  const explicitStart = parseDateInput(startAt);
+  const explicitEnd = parseDateInput(endAt);
+  if (explicitStart || explicitEnd) {
+    return {
+      writtenAtStart: explicitStart || undefined,
+      writtenAtEnd: explicitEnd || undefined,
+      label: [explicitStart ? shanghaiYmd(explicitStart) : '…', explicitEnd ? shanghaiYmd(explicitEnd) : '…'].join(' ~ ')
+    };
+  }
+
+  const now = new Date();
+  if (week === 'this' || week === 'last') {
+    const todayStart = startOfShanghaiDay(now);
+    const monOffset = shanghaiWeekdayMon0(now);
+    const thisMonday = new Date(todayStart.getTime() - monOffset * DAY_MS);
+    const rangeStart = week === 'this' ? thisMonday : new Date(thisMonday.getTime() - 7 * DAY_MS);
+    const rangeEndExclusive = week === 'this' ? new Date(thisMonday.getTime() + 7 * DAY_MS) : thisMonday;
+    // end 用开区间前一毫秒，便于 Op.lte
+    const writtenAtEnd = new Date(rangeEndExclusive.getTime() - 1);
+    return {
+      writtenAtStart: rangeStart,
+      writtenAtEnd,
+      label: `${shanghaiYmd(rangeStart)} ~ ${shanghaiYmd(writtenAtEnd)}${week === 'this' ? '（本周）' : '（上周）'}`
+    };
+  }
+
+  const lookback = Number.isFinite(Number(days)) && Number(days) > 0 ? Number(days) : 7;
+  const writtenAtStart = new Date(now.getTime() - lookback * DAY_MS);
+  return {
+    writtenAtStart,
+    writtenAtEnd: now,
+    label: `近 ${lookback} 天（${shanghaiYmd(writtenAtStart)} ~ ${shanghaiYmd(now)}）`
+  };
+};
+
+module.exports = {
+  parseDateInput,
+  resolveWrittenAtRange,
+  shanghaiYmd
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- 新增 MCP 工具 `search_worklog`，按时间与创建人筛选工作日志并输出周报素材 markdown
- 时间：`week=this|last`（上海时区周一～周日）、`days`、`startAt/endAt`
- 创建人：`mine`、`creator`（昵称/邮箱/id）、`createdUserId`；另支持 `project` / `query`
- `filterOptions` 增加 creators 列表；server `1.0.10 → 1.0.11`

## Test plan
- [ ] `search_worklog({ week: "this", mine: true })` 仅返回当前用户本周日志
- [ ] `search_worklog({ startAt: "2026-09-01", endAt: "2026-09-03", creator: "<昵称>" })` 按人+时间筛选
- [ ] 创建人模糊匹配多人时返回候选 id 列表
- [ ] `mode: "list"` 输出紧凑列表

## Version
server: 1.0.10 → 1.0.11

Made with [Cursor](https://cursor.com)